### PR TITLE
feat(cli): add pforge smith — inspect your forge before you build

### DIFF
--- a/AGENT-SETUP.md
+++ b/AGENT-SETUP.md
@@ -299,6 +299,7 @@ Once setup and validation pass, the agent can run the 5-step planning pipeline.
 If `pforge.ps1` (Windows) or `pforge.sh` (macOS/Linux) exists in the repo root, use CLI commands for project management tasks:
 
 ```
+pforge smith                          # Inspect the forge (environment + setup health)
 pforge check                          # Validate setup
 pforge status                         # Show all phases with status
 pforge new-phase <feature-name>       # Create plan file + roadmap entry

--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -715,6 +715,7 @@ The `pforge` CLI is a convenience wrapper — every command shows the equivalent
 ```
 pforge init              Bootstrap project (delegates to setup.ps1/sh)
 pforge check             Validate setup (delegates to validate-setup.ps1/sh)
+pforge smith             Inspect the forge — environment, VS Code config, setup health, common problems
 pforge status            Show phase status from DEPLOYMENT-ROADMAP.md
 pforge new-phase <name>  Create plan file + add to roadmap
 pforge branch <plan>     Create branch from plan's Branch Strategy

--- a/README.md
+++ b/README.md
@@ -819,7 +819,7 @@ This tells Copilot to walk up to the `.git` root and discover all instruction fi
 | `pforge` command not found | CLI scripts not in repo root | Copy `pforge.ps1`/`pforge.sh` from the template, or use manual steps |
 | "Not inside a git repository" from CLI | Running `pforge` outside a git-initialized directory | `cd` into your project root, or run `git init` first |
 | Setup overwrites existing files | Used `-Force` flag on a brownfield project | Re-run without `-Force`; see AGENT-SETUP.md Section 2 for merge guidance |
-| Plan hardening agent drifts | Missing or stale instruction files | Run `pforge check` to verify all guardrail files exist |
+| Plan hardening agent drifts | Missing or stale instruction files | Run `pforge smith` to inspect the forge, or `pforge check` to verify guardrail files |
 | Framework files outdated | New version of Plan Forge available | Run `pforge update <source-path>` — see [CLI Guide](docs/CLI-GUIDE.md#pforge-update-source-path) |
 
 For CLI-specific issues, see [docs/CLI-GUIDE.md → Troubleshooting](docs/CLI-GUIDE.md#troubleshooting).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ See [CHANGELOG.md](CHANGELOG.md) for full release notes.
 
 ### v1.4 — Enhanced Automation
 - Auto-update notification when source version is newer
-- `pforge doctor` — diagnose common setup problems
+- ~~`pforge doctor`~~ → shipped as `pforge smith` in v1.3.0
 - Preset-specific validation minimum count checks in `validate-setup`
 
 ### v1.5 — Intelligence Layer

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -436,6 +436,64 @@ curl -sL https://raw.githubusercontent.com/srnichols/plan-forge/master/pforge.sh
 
 ---
 
+### `pforge smith`
+
+Inspect your forge — diagnose your environment, VS Code configuration, setup health, version currency, and common problems. Every issue includes a `FIX:` suggestion.
+
+```powershell
+# PowerShell
+.\pforge.ps1 smith
+```
+
+```bash
+# Bash
+./pforge.sh smith
+```
+
+**What The Smith checks:**
+
+| Category | Checks |
+|----------|--------|
+| **Environment** | git, VS Code CLI, PowerShell/bash version, GitHub CLI |
+| **VS Code Config** | `chat.agent.enabled`, `chat.useCustomizationsInParentRepositories`, `chat.promptFiles` |
+| **Setup Health** | `.forge.json` valid, `copilot-instructions.md` exists, file counts match preset expectations |
+| **Version Currency** | Compare installed `templateVersion` vs source `VERSION` |
+| **Common Problems** | Duplicate instructions, orphaned agents, missing `applyTo`, unresolved placeholders |
+
+**Example output:**
+```
+╔══════════════════════════════════════════════════════════════╗
+║       Plan Forge — The Smith                                 ║
+╚══════════════════════════════════════════════════════════════╝
+
+Environment:
+  ✅ git 2.44.0
+  ✅ code (VS Code CLI) 1.99.0
+  ✅ PowerShell 7.5.0
+
+VS Code Configuration:
+  ✅ chat.agent.enabled = true
+  ❌ chat.useCustomizationsInParentRepositories not set
+     FIX: Add "chat.useCustomizationsInParentRepositories": true to .vscode/settings.json
+
+Setup Health:
+  ✅ .forge.json valid (preset: dotnet, v1.3.0)
+  ✅ 16 instruction files (expected: >=14 for dotnet)
+
+────────────────────────────────────────────────────
+  Results:  8 passed  |  1 failed  |  2 warnings
+────────────────────────────────────────────────────
+```
+
+**Equivalent manual steps:**
+1. Check that required tools are installed (git, VS Code, PowerShell)
+2. Verify VS Code settings for Copilot agent mode
+3. Validate `.forge.json` and file counts per preset
+4. Check version currency against Plan Forge source
+5. Scan for common problems (duplicates, orphans, broken references)
+
+---
+
 ### `pforge help`
 
 Show all available commands.
@@ -469,6 +527,7 @@ Show all available commands.
 | Scope drift check | `pforge diff <plan>` | git diff + manual comparison to Scope Contract |
 | Install extension | `pforge ext install <path>` | Copy files to 3 directories |
 | Update framework | `pforge update [source]` | Clone latest Plan Forge, manually copy framework files |
+| Inspect the forge | `pforge smith` | Manually check tools, VS Code settings, file counts, version |
 | Harden a plan | *(use prompt)* | Paste Step 2 prompt into Copilot |
 | Execute slices | *(use prompt)* | Paste Step 3 prompt into Copilot |
 | Review & audit | *(use prompt)* | Paste Step 5 prompt into Copilot |
@@ -539,6 +598,7 @@ IF pforge.ps1 does NOT exist in repo root
 Use CLI when:
   • Creating a new phase         → pforge new-phase <name>
   • Checking setup validity       → pforge check
+  • Inspecting the forge          → pforge smith
   • Reading roadmap status        → pforge status
   • Creating a branch from a plan → pforge branch <plan>
   • Installing an extension       → pforge ext install <path>
@@ -555,8 +615,9 @@ Do NOT use CLI when:
 When setting up a new feature for a user:
 
 ```
-1. pforge check                          # Verify setup is valid
-2. pforge new-phase <feature-name>       # Create plan file + roadmap entry
+1. pforge smith                          # Inspect the forge (environment + setup)
+2. pforge check                          # Verify setup files are valid
+3. pforge new-phase <feature-name>       # Create plan file + roadmap entry
 3. pforge phase-status <plan-file> in-progress  # Mark phase as active
 4. pforge branch <plan-file> --dry-run   # Show what branch would be created
 5. (ask user to confirm branch name)

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -97,7 +97,7 @@
           </a>
           <a href="https://github.com/srnichols/plan-forge/blob/master/docs/CLI-GUIDE.md" class="p-5 rounded-xl bg-slate-800/60 border border-slate-700/40 hover:border-forge-500/40 transition-colors group">
             <h3 class="font-semibold text-white group-hover:text-forge-400 transition-colors mb-1">CLI Guide</h3>
-            <p class="text-sm text-slate-400">All <code class="text-forge-400">pforge</code> commands — init, check, status, new-phase, branch, commit, sweep, diff, ext install.</p>
+            <p class="text-sm text-slate-400">All <code class="text-forge-400">pforge</code> commands — init, check, smith, status, new-phase, branch, commit, sweep, diff, ext install.</p>
           </a>
           <a href="https://github.com/srnichols/plan-forge/blob/master/docs/EXTENSIONS.md" class="p-5 rounded-xl bg-slate-800/60 border border-slate-700/40 hover:border-forge-500/40 transition-colors group">
             <h3 class="font-semibold text-white group-hover:text-forge-400 transition-colors mb-1">Extensions Guide</h3>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -167,6 +167,24 @@
               Set <code class="text-forge-400">chat.useCustomizationsInParentRepositories</code> in VS Code settings so child workspaces inherit parent guardrails. Run multi-preset setup with different stacks for different directories (e.g., <code class="text-forge-400">-Preset typescript,azure-iac -ProjectPath ./packages/api</code>).
             </div>
           </details>
+
+          <details class="faq-item group rounded-xl bg-slate-800/60 border border-slate-700/40 overflow-hidden">
+            <summary class="flex items-center justify-between px-6 py-4 cursor-pointer hover:bg-slate-800/80 transition-colors">
+              <span class="text-sm font-medium text-white pr-4">What is "The Smith" and when should I run it?</span>
+              <svg class="w-4 h-4 text-slate-500 group-open:rotate-180 transition-transform shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+            </summary>
+            <div class="px-6 pb-5 text-sm text-slate-400 leading-relaxed border-t border-slate-700/30 pt-4">
+              <p class="mb-3">A blacksmith inspects the forge, checks the tools, and makes sure everything is ready before the work begins. <code class="text-forge-400">pforge smith</code> does the same for your project — it diagnoses five areas in seconds:</p>
+              <ul class="list-disc list-inside space-y-1 mb-3">
+                <li><strong>Environment</strong> — git, VS Code CLI, PowerShell/bash, GitHub CLI</li>
+                <li><strong>VS Code Config</strong> — agent mode, parent repo customizations, prompt file discovery</li>
+                <li><strong>Setup Health</strong> — .forge.json, file counts per preset, copilot-instructions.md</li>
+                <li><strong>Version Currency</strong> — is your Plan Forge install up to date?</li>
+                <li><strong>Common Problems</strong> — duplicate files, orphaned agents, missing applyTo, unresolved placeholders</li>
+              </ul>
+              <p>Every issue includes a <strong>FIX:</strong> suggestion with the exact command or setting to resolve it. Run it after setup, after updates, or whenever something feels off.</p>
+            </div>
+          </details>
         </div>
       </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -554,6 +554,19 @@
           <p class="text-sm text-slate-400">Hooks run automatically at agent lifecycle points — blocking edits to forbidden paths, warning on TODO markers, auto-formatting, and alerting when code ships without tests.</p>
         </div>
 
+        <!-- The Smith -->
+        <div class="p-8 rounded-2xl bg-slate-800/60 border border-slate-700/50">
+          <div class="w-12 h-12 rounded-xl bg-amber-500/20 flex items-center justify-center text-2xl mb-4">🔨</div>
+          <h3 class="text-xl font-bold text-white mb-2">The Smith</h3>
+          <p class="text-sm text-slate-400 mb-4">Run <code class="text-forge-400">pforge smith</code> to inspect your forge before you build. Diagnoses your environment, VS Code configuration, setup health, version currency, and common problems — with actionable fix suggestions for every issue.</p>
+          <div class="space-y-2">
+            <div class="flex items-center gap-2 text-xs"><span class="text-green-400">✅</span> <span class="text-slate-400">git 2.44.0</span></div>
+            <div class="flex items-center gap-2 text-xs"><span class="text-green-400">✅</span> <span class="text-slate-400">16 instruction files (expected: ≥14)</span></div>
+            <div class="flex items-center gap-2 text-xs"><span class="text-red-400">❌</span> <span class="text-slate-400">chat.promptFiles not set</span></div>
+            <div class="text-xs text-yellow-400 pl-5">FIX: Add to .vscode/settings.json</div>
+          </div>
+        </div>
+
       </div>
 
       <!-- What's the difference? -->

--- a/pforge.ps1
+++ b/pforge.ps1
@@ -70,6 +70,7 @@ function Show-Help {
     Write-Host "  ext list          List installed extensions"
     Write-Host "  ext remove <name> Remove an installed extension"
     Write-Host "  update [source]   Update framework files from Plan Forge source (preserves customizations)"
+    Write-Host "  smith             Inspect your forge — environment, VS Code config, setup health, and common problems"
     Write-Host "  help              Show this help message"
     Write-Host ""
     Write-Host "OPTIONS:" -ForegroundColor Yellow
@@ -1085,6 +1086,410 @@ function Invoke-Update {
     Write-Host "Run 'pforge check' to validate the updated setup." -ForegroundColor DarkGray
 }
 
+# ─── Command: smith ────────────────────────────────────────────────────
+function Invoke-Smith {
+    Write-ManualSteps "smith" @(
+        "Check that required tools are installed (git, VS Code, PowerShell)"
+        "Verify VS Code settings for Copilot agent mode"
+        "Validate .forge.json and file counts per preset"
+        "Check version currency against Plan Forge source"
+        "Scan for common problems (duplicates, orphans, broken references)"
+    )
+
+    $doc = @{ Pass = 0; Fail = 0; Warn = 0 }
+
+    function Doctor-Pass([string]$Msg) {
+        Write-Host "  ✅ $Msg" -ForegroundColor Green
+        $doc.Pass++
+    }
+    function Doctor-Fail([string]$Msg, [string]$Fix = '') {
+        Write-Host "  ❌ $Msg" -ForegroundColor Red
+        if ($Fix) { Write-Host "     FIX: $Fix" -ForegroundColor Yellow }
+        $doc.Fail++
+    }
+    function Doctor-Warn([string]$Msg, [string]$Fix = '') {
+        Write-Host "  ⚠️  $Msg" -ForegroundColor Yellow
+        if ($Fix) { Write-Host "     FIX: $Fix" -ForegroundColor DarkYellow }
+        $doc.Warn++
+    }
+
+    Write-Host ""
+    Write-Host "╔══════════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
+    Write-Host "║       Plan Forge — The Smith                                  ║" -ForegroundColor Cyan
+    Write-Host "╚══════════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
+    Write-Host ""
+
+    # ═══════════════════════════════════════════════════════════════
+    # 1. ENVIRONMENT
+    # ═══════════════════════════════════════════════════════════════
+    Write-Host "Environment:" -ForegroundColor Cyan
+
+    # Git
+    $gitVersion = git --version 2>$null
+    if ($LASTEXITCODE -eq 0 -and $gitVersion) {
+        $ver = ($gitVersion -replace 'git version ', '').Trim()
+        Doctor-Pass "git $ver"
+    }
+    else {
+        Doctor-Fail "git not found" "Install from https://git-scm.com/downloads"
+    }
+
+    # VS Code CLI
+    $codeCmd = Get-Command code -ErrorAction SilentlyContinue
+    if ($codeCmd) {
+        $codeVer = (code --version 2>$null | Select-Object -First 1)
+        if ($codeVer) {
+            Doctor-Pass "code (VS Code CLI) $codeVer"
+        }
+        else {
+            Doctor-Pass "code (VS Code CLI) found"
+        }
+    }
+    else {
+        $codeInsiders = Get-Command code-insiders -ErrorAction SilentlyContinue
+        if ($codeInsiders) {
+            Doctor-Pass "code-insiders (VS Code CLI) found"
+        }
+        else {
+            Doctor-Warn "VS Code CLI not in PATH (optional)" "Open VS Code → Ctrl+Shift+P → 'Shell Command: Install code in PATH'"
+        }
+    }
+
+    # PowerShell version
+    $psVer = $PSVersionTable.PSVersion.ToString()
+    if ($PSVersionTable.PSVersion.Major -ge 7) {
+        Doctor-Pass "PowerShell $psVer"
+    }
+    elseif ($PSVersionTable.PSVersion.Major -ge 5) {
+        Doctor-Warn "PowerShell $psVer (7.x recommended)" "Install from https://aka.ms/powershell"
+    }
+    else {
+        Doctor-Fail "PowerShell $psVer (5.1+ required)" "Install from https://aka.ms/powershell"
+    }
+
+    # Optional: GitHub CLI
+    $ghCmd = Get-Command gh -ErrorAction SilentlyContinue
+    if ($ghCmd) {
+        $ghVer = (gh --version 2>$null | Select-Object -First 1) -replace 'gh version ', '' -replace ' .*', ''
+        Doctor-Pass "gh (GitHub CLI) $ghVer"
+    }
+    else {
+        Doctor-Warn "gh (GitHub CLI) not found (optional — useful for PRs and branch protection)" "Install from https://cli.github.com/"
+    }
+
+    Write-Host ""
+
+    # ═══════════════════════════════════════════════════════════════
+    # 2. VS CODE CONFIGURATION
+    # ═══════════════════════════════════════════════════════════════
+    Write-Host "VS Code Configuration:" -ForegroundColor Cyan
+
+    $settingsPath = Join-Path $RepoRoot ".vscode/settings.json"
+    if (Test-Path $settingsPath) {
+        try {
+            $settings = Get-Content $settingsPath -Raw | ConvertFrom-Json
+
+            # chat.agent.enabled (may not exist in newer VS Code where it's default)
+            if ($null -ne $settings.'chat.agent.enabled') {
+                if ($settings.'chat.agent.enabled' -eq $true) {
+                    Doctor-Pass "chat.agent.enabled = true"
+                }
+                else {
+                    Doctor-Fail "chat.agent.enabled = false" 'Set to true in .vscode/settings.json'
+                }
+            }
+            else {
+                Doctor-Pass "chat.agent.enabled (default — OK)"
+            }
+
+            # chat.useCustomizationsInParentRepositories
+            if ($null -ne $settings.'chat.useCustomizationsInParentRepositories') {
+                if ($settings.'chat.useCustomizationsInParentRepositories' -eq $true) {
+                    Doctor-Pass "chat.useCustomizationsInParentRepositories = true"
+                }
+                else {
+                    Doctor-Warn "chat.useCustomizationsInParentRepositories = false" 'Set to true for monorepo support'
+                }
+            }
+            else {
+                Doctor-Warn "chat.useCustomizationsInParentRepositories not set" 'Add "chat.useCustomizationsInParentRepositories": true to .vscode/settings.json'
+            }
+
+            # chat.promptFiles
+            if ($null -ne $settings.'chat.promptFiles') {
+                if ($settings.'chat.promptFiles' -eq $true) {
+                    Doctor-Pass "chat.promptFiles = true"
+                }
+                else {
+                    Doctor-Warn "chat.promptFiles is not true" 'Set to true to enable prompt template discovery'
+                }
+            }
+            else {
+                Doctor-Warn "chat.promptFiles not set" 'Add "chat.promptFiles": true to .vscode/settings.json'
+            }
+        }
+        catch {
+            Doctor-Fail ".vscode/settings.json has invalid JSON" "Fix the JSON syntax in .vscode/settings.json"
+        }
+    }
+    else {
+        Doctor-Warn ".vscode/settings.json not found" "Run 'pforge init' or create it manually"
+    }
+
+    Write-Host ""
+
+    # ═══════════════════════════════════════════════════════════════
+    # 3. SETUP HEALTH
+    # ═══════════════════════════════════════════════════════════════
+    Write-Host "Setup Health:" -ForegroundColor Cyan
+
+    $configPath = Join-Path $RepoRoot ".forge.json"
+    $preset = 'unknown'
+    $templateVersion = 'unknown'
+
+    if (Test-Path $configPath) {
+        try {
+            $config = Get-Content $configPath -Raw | ConvertFrom-Json
+            $preset = $config.preset
+            $templateVersion = $config.templateVersion
+            Doctor-Pass ".forge.json valid (preset: $preset, v$templateVersion)"
+        }
+        catch {
+            Doctor-Fail ".forge.json has invalid JSON" "Delete and re-run 'pforge init'"
+            $preset = 'unknown'
+        }
+    }
+    else {
+        Doctor-Fail ".forge.json not found" "Run 'pforge init' to bootstrap your project"
+    }
+
+    # copilot-instructions.md
+    $copilotInstr = Join-Path $RepoRoot ".github/copilot-instructions.md"
+    if (Test-Path $copilotInstr) {
+        Doctor-Pass ".github/copilot-instructions.md exists"
+    }
+    else {
+        Doctor-Fail ".github/copilot-instructions.md missing" "Run 'pforge init' to create it"
+    }
+
+    # File count expectations per preset
+    $expectedCounts = @{
+        'dotnet'     = @{ instructions = 14; agents = 17; prompts = 9; skills = 8 }
+        'typescript' = @{ instructions = 14; agents = 17; prompts = 9; skills = 8 }
+        'python'     = @{ instructions = 14; agents = 17; prompts = 9; skills = 8 }
+        'java'       = @{ instructions = 14; agents = 17; prompts = 9; skills = 8 }
+        'go'         = @{ instructions = 14; agents = 17; prompts = 9; skills = 8 }
+        'azure-iac'  = @{ instructions = 14; agents = 17; prompts = 9; skills = 8 }
+        'custom'     = @{ instructions = 3;  agents = 5;  prompts = 7; skills = 0 }
+    }
+
+    # Handle multi-preset (e.g., "dotnet,azure-iac")
+    $presetKey = $preset
+    if ($preset -match ',') {
+        $presetKey = ($preset -split ',')[0].Trim()
+    }
+
+    if ($expectedCounts.ContainsKey($presetKey)) {
+        $expected = $expectedCounts[$presetKey]
+
+        $instrDir = Join-Path $RepoRoot ".github/instructions"
+        $agentsDir = Join-Path $RepoRoot ".github/agents"
+        $promptsDir = Join-Path $RepoRoot ".github/prompts"
+        $skillsDir = Join-Path $RepoRoot ".github/skills"
+
+        # Instructions
+        $instrCount = 0
+        if (Test-Path $instrDir) {
+            $instrCount = (Get-ChildItem -Path $instrDir -Filter "*.instructions.md" -File).Count
+        }
+        if ($instrCount -ge $expected.instructions) {
+            Doctor-Pass "$instrCount instruction files (expected: >=$($expected.instructions) for $presetKey)"
+        }
+        else {
+            Doctor-Warn "$instrCount instruction files (expected: >=$($expected.instructions) for $presetKey)" "Run 'pforge update' to get missing files"
+        }
+
+        # Agents
+        $agentCount = 0
+        if (Test-Path $agentsDir) {
+            $agentCount = (Get-ChildItem -Path $agentsDir -Filter "*.agent.md" -File).Count
+        }
+        if ($agentCount -ge $expected.agents) {
+            Doctor-Pass "$agentCount agent definitions (expected: >=$($expected.agents) for $presetKey)"
+        }
+        else {
+            Doctor-Warn "$agentCount agent definitions (expected: >=$($expected.agents) for $presetKey)" "Run 'pforge update' to get missing agents"
+        }
+
+        # Prompts
+        $promptCount = 0
+        if (Test-Path $promptsDir) {
+            $promptCount = (Get-ChildItem -Path $promptsDir -Filter "*.prompt.md" -File).Count
+        }
+        if ($promptCount -ge $expected.prompts) {
+            Doctor-Pass "$promptCount prompt templates (expected: >=$($expected.prompts) for $presetKey)"
+        }
+        else {
+            Doctor-Warn "$promptCount prompt templates (expected: >=$($expected.prompts) for $presetKey)" "Run 'pforge update' to get missing prompts"
+        }
+
+        # Skills
+        $skillCount = 0
+        if (Test-Path $skillsDir) {
+            $skillCount = (Get-ChildItem -Path $skillsDir -Recurse -Filter "SKILL.md" -File).Count
+        }
+        if ($skillCount -ge $expected.skills) {
+            Doctor-Pass "$skillCount skills (expected: >=$($expected.skills) for $presetKey)"
+        }
+        else {
+            Doctor-Warn "$skillCount skills (expected: >=$($expected.skills) for $presetKey)" "Run 'pforge update' to get missing skills"
+        }
+    }
+
+    Write-Host ""
+
+    # ═══════════════════════════════════════════════════════════════
+    # 4. VERSION CURRENCY
+    # ═══════════════════════════════════════════════════════════════
+    Write-Host "Version Currency:" -ForegroundColor Cyan
+
+    $sourceVersion = $null
+    # Try to find Plan Forge source nearby
+    $candidates = @(
+        (Join-Path (Split-Path $RepoRoot -Parent) "plan-forge"),
+        (Join-Path (Split-Path $RepoRoot -Parent) "Plan-Forge")
+    )
+    foreach ($c in $candidates) {
+        $vFile = Join-Path $c "VERSION"
+        if (Test-Path $vFile) {
+            $sourceVersion = (Get-Content $vFile -Raw).Trim()
+            break
+        }
+    }
+
+    if ($sourceVersion) {
+        if ($templateVersion -eq $sourceVersion) {
+            Doctor-Pass "Up to date (v$templateVersion)"
+        }
+        elseif ($templateVersion -eq 'unknown') {
+            Doctor-Warn "Cannot determine installed version (.forge.json missing)"
+        }
+        else {
+            Doctor-Warn "Installed v$templateVersion — latest is v$sourceVersion" "Run 'pforge update' to upgrade"
+        }
+    }
+    else {
+        Doctor-Pass "Installed v$templateVersion (source repo not found nearby — skipping currency check)"
+    }
+
+    Write-Host ""
+
+    # ═══════════════════════════════════════════════════════════════
+    # 5. COMMON PROBLEMS
+    # ═══════════════════════════════════════════════════════════════
+    Write-Host "Common Problems:" -ForegroundColor Cyan
+
+    $problemsFound = $false
+
+    # 5a. Duplicate instruction files (same base name, different case)
+    $instrDir = Join-Path $RepoRoot ".github/instructions"
+    if (Test-Path $instrDir) {
+        $instrFiles = Get-ChildItem -Path $instrDir -Filter "*.instructions.md" -File
+        $lowerNames = @{}
+        foreach ($f in $instrFiles) {
+            $lower = $f.Name.ToLower()
+            if ($lowerNames.ContainsKey($lower)) {
+                Doctor-Fail "Duplicate instruction: $($f.Name) and $($lowerNames[$lower])" "Remove one of the duplicates from .github/instructions/"
+                $problemsFound = $true
+            }
+            else {
+                $lowerNames[$lower] = $f.Name
+            }
+        }
+    }
+
+    # 5b. Orphaned agents — referenced in AGENTS.md but file missing
+    $agentsMdPath = Join-Path $RepoRoot "AGENTS.md"
+    $agentsDir = Join-Path $RepoRoot ".github/agents"
+    if ((Test-Path $agentsMdPath) -and (Test-Path $agentsDir)) {
+        $agentsMdContent = Get-Content $agentsMdPath -Raw
+        $referencedAgents = [regex]::Matches($agentsMdContent, '`([^`]+\.agent\.md)`') | ForEach-Object { $_.Groups[1].Value }
+        $actualAgents = Get-ChildItem -Path $agentsDir -Filter "*.agent.md" -File | ForEach-Object { $_.Name }
+
+        foreach ($ref in $referencedAgents) {
+            if ($ref -notin $actualAgents) {
+                Doctor-Warn "AGENTS.md references '$ref' but file not found in .github/agents/" "Remove from AGENTS.md or run 'pforge update'"
+                $problemsFound = $true
+            }
+        }
+    }
+
+    # 5c. Instruction files with missing or broken applyTo frontmatter
+    if (Test-Path $instrDir) {
+        foreach ($f in (Get-ChildItem -Path $instrDir -Filter "*.instructions.md" -File)) {
+            $content = Get-Content $f.FullName -Raw
+            if ($content -match '^---\s*\n') {
+                if ($content -notmatch 'applyTo\s*:') {
+                    Doctor-Warn "$($f.Name) has frontmatter but no applyTo pattern" "Add 'applyTo: **' or a specific glob pattern"
+                    $problemsFound = $true
+                }
+            }
+        }
+    }
+
+    # 5d. copilot-instructions.md still has placeholders
+    if (Test-Path $copilotInstr) {
+        $ciContent = Get-Content $copilotInstr -Raw
+        $placeholders = @('<YOUR PROJECT NAME>', '<YOUR TECH STACK>', '<YOUR BUILD COMMAND>', '<YOUR TEST COMMAND>', '<YOUR LINT COMMAND>', '<YOUR DEV COMMAND>', '<DATE>')
+        $foundPlaceholders = @()
+        foreach ($ph in $placeholders) {
+            if ($ciContent -match [regex]::Escape($ph)) {
+                $foundPlaceholders += $ph
+            }
+        }
+        if ($foundPlaceholders.Count -gt 0) {
+            Doctor-Warn "copilot-instructions.md has $($foundPlaceholders.Count) unresolved placeholder(s): $($foundPlaceholders -join ', ')" "Edit .github/copilot-instructions.md and fill in your project details"
+            $problemsFound = $true
+        }
+    }
+
+    # 5e. Roadmap file missing
+    $roadmapPath = Join-Path $RepoRoot "docs/plans/DEPLOYMENT-ROADMAP.md"
+    if (-not (Test-Path $roadmapPath)) {
+        Doctor-Warn "DEPLOYMENT-ROADMAP.md not found" "Run 'pforge init' or create docs/plans/DEPLOYMENT-ROADMAP.md"
+        $problemsFound = $true
+    }
+
+    if (-not $problemsFound) {
+        Doctor-Pass "No common problems detected"
+    }
+
+    # ═══════════════════════════════════════════════════════════════
+    # SUMMARY
+    # ═══════════════════════════════════════════════════════════════
+    Write-Host ""
+    Write-Host "────────────────────────────────────────────────────" -ForegroundColor Gray
+    $summaryColor = if ($doc.Fail -gt 0) { 'Red' } elseif ($doc.Warn -gt 0) { 'Yellow' } else { 'Green' }
+    Write-Host "  Results:  $($doc.Pass) passed  |  $($doc.Fail) failed  |  $($doc.Warn) warnings" -ForegroundColor $summaryColor
+    Write-Host "────────────────────────────────────────────────────" -ForegroundColor Gray
+
+    if ($doc.Fail -gt 0) {
+        Write-Host ""
+        Write-Host "Fix the $($doc.Fail) issue(s) above for the best Plan Forge experience." -ForegroundColor Red
+        exit 1
+    }
+    elseif ($doc.Warn -gt 0) {
+        Write-Host ""
+        Write-Host "$($doc.Warn) warning(s) — review the suggestions above." -ForegroundColor Yellow
+        exit 0
+    }
+    else {
+        Write-Host ""
+        Write-Host "Your forge is ready. Happy smithing!" -ForegroundColor Green
+        exit 0
+    }
+}
+
 # ─── Command Router ────────────────────────────────────────────────────
 switch ($Command) {
     'init'         { Invoke-Init }
@@ -1098,6 +1503,7 @@ switch ($Command) {
     'diff'         { Invoke-Diff }
     'ext'          { Invoke-Ext }
     'update'       { Invoke-Update }
+    'smith'        { Invoke-Smith }
     'help'         { Show-Help }
     ''             { Show-Help }
     '--help'       { Show-Help }

--- a/pforge.sh
+++ b/pforge.sh
@@ -54,6 +54,7 @@ COMMANDS:
   ext list          List installed extensions
   ext remove <name> Remove an installed extension
   update [source]   Update framework files from Plan Forge source (preserves customizations)
+  smith             Inspect your forge — environment, VS Code config, setup health, and common problems
   help              Show this help message
 
 OPTIONS:
@@ -980,6 +981,294 @@ with open('$config_path', 'w') as f:
     echo "Run 'pforge check' to validate the updated setup."
 }
 
+# ─── Command: doctor ───────────────────────────────────────────────────
+cmd_doctor() {
+    print_manual_steps "smith" \
+        "Check that required tools are installed (git, VS Code, bash)" \
+        "Verify VS Code settings for Copilot agent mode" \
+        "Validate .forge.json and file counts per preset" \
+        "Check version currency against Plan Forge source" \
+        "Scan for common problems (duplicates, orphans, broken references)"
+
+    local d_pass=0 d_fail=0 d_warn=0
+
+    doctor_pass()  { echo "  ✅ $1"; d_pass=$((d_pass + 1)); }
+    doctor_fail()  { echo "  ❌ $1"; [ -n "${2:-}" ] && echo "     FIX: $2"; d_fail=$((d_fail + 1)); }
+    doctor_warn()  { echo "  ⚠️  $1"; [ -n "${2:-}" ] && echo "     FIX: $2"; d_warn=$((d_warn + 1)); }
+
+    echo ""
+    echo "╔══════════════════════════════════════════════════════════════╗"
+    echo "║       Plan Forge — The Smith                                  ║"
+    echo "╚══════════════════════════════════════════════════════════════╝"
+    echo ""
+
+    # ═══════════════════════════════════════════════════════════════
+    # 1. ENVIRONMENT
+    # ═══════════════════════════════════════════════════════════════
+    echo "Environment:"
+
+    # Git
+    if command -v git &>/dev/null; then
+        local git_ver
+        git_ver="$(git --version 2>/dev/null | sed 's/git version //')"
+        doctor_pass "git $git_ver"
+    else
+        doctor_fail "git not found" "Install from https://git-scm.com/downloads"
+    fi
+
+    # VS Code CLI
+    if command -v code &>/dev/null; then
+        local code_ver
+        code_ver="$(code --version 2>/dev/null | head -1)"
+        doctor_pass "code (VS Code CLI) ${code_ver:-found}"
+    elif command -v code-insiders &>/dev/null; then
+        doctor_pass "code-insiders (VS Code CLI) found"
+    else
+        doctor_warn "VS Code CLI not in PATH (optional)" "Open VS Code → Cmd+Shift+P → 'Shell Command: Install code in PATH'"
+    fi
+
+    # Bash version
+    local bash_ver="${BASH_VERSION:-unknown}"
+    doctor_pass "bash $bash_ver"
+
+    # Optional: GitHub CLI
+    if command -v gh &>/dev/null; then
+        local gh_ver
+        gh_ver="$(gh --version 2>/dev/null | head -1 | sed 's/gh version //' | sed 's/ .*//')"
+        doctor_pass "gh (GitHub CLI) $gh_ver"
+    else
+        doctor_warn "gh (GitHub CLI) not found (optional)" "Install from https://cli.github.com/"
+    fi
+
+    echo ""
+
+    # ═══════════════════════════════════════════════════════════════
+    # 2. VS CODE CONFIGURATION
+    # ═══════════════════════════════════════════════════════════════
+    echo "VS Code Configuration:"
+
+    local settings_path="$REPO_ROOT/.vscode/settings.json"
+    if [ -f "$settings_path" ]; then
+        # Check for key settings (basic grep — no jq dependency required)
+        if grep -q '"chat.agent.enabled"' "$settings_path" 2>/dev/null; then
+            if grep -q '"chat.agent.enabled":\s*true' "$settings_path" 2>/dev/null || grep -q '"chat.agent.enabled": true' "$settings_path" 2>/dev/null; then
+                doctor_pass "chat.agent.enabled = true"
+            else
+                doctor_fail "chat.agent.enabled = false" "Set to true in .vscode/settings.json"
+            fi
+        else
+            doctor_pass "chat.agent.enabled (default — OK)"
+        fi
+
+        if grep -q '"chat.useCustomizationsInParentRepositories"' "$settings_path" 2>/dev/null; then
+            if grep -q '"chat.useCustomizationsInParentRepositories": true' "$settings_path" 2>/dev/null; then
+                doctor_pass "chat.useCustomizationsInParentRepositories = true"
+            else
+                doctor_warn "chat.useCustomizationsInParentRepositories is not true" "Set to true for monorepo support"
+            fi
+        else
+            doctor_warn "chat.useCustomizationsInParentRepositories not set" 'Add "chat.useCustomizationsInParentRepositories": true to .vscode/settings.json'
+        fi
+
+        if grep -q '"chat.promptFiles"' "$settings_path" 2>/dev/null; then
+            if grep -q '"chat.promptFiles": true' "$settings_path" 2>/dev/null; then
+                doctor_pass "chat.promptFiles = true"
+            else
+                doctor_warn "chat.promptFiles is not true" "Set to true to enable prompt template discovery"
+            fi
+        else
+            doctor_warn "chat.promptFiles not set" 'Add "chat.promptFiles": true to .vscode/settings.json'
+        fi
+    else
+        doctor_warn ".vscode/settings.json not found" "Run 'pforge init' or create it manually"
+    fi
+
+    echo ""
+
+    # ═══════════════════════════════════════════════════════════════
+    # 3. SETUP HEALTH
+    # ═══════════════════════════════════════════════════════════════
+    echo "Setup Health:"
+
+    local config_path="$REPO_ROOT/.forge.json"
+    local preset="unknown"
+    local template_version="unknown"
+
+    if [ -f "$config_path" ]; then
+        # Parse with grep/sed (no jq dependency)
+        preset="$(grep -o '"preset"[^,}]*' "$config_path" | sed 's/"preset":\s*"//' | sed 's/"//' || echo "unknown")"
+        template_version="$(grep -o '"templateVersion"[^,}]*' "$config_path" | sed 's/"templateVersion":\s*"//' | sed 's/"//' || echo "unknown")"
+        doctor_pass ".forge.json valid (preset: $preset, v$template_version)"
+    else
+        doctor_fail ".forge.json not found" "Run 'pforge init' to bootstrap your project"
+    fi
+
+    local copilot_instr="$REPO_ROOT/.github/copilot-instructions.md"
+    if [ -f "$copilot_instr" ]; then
+        doctor_pass ".github/copilot-instructions.md exists"
+    else
+        doctor_fail ".github/copilot-instructions.md missing" "Run 'pforge init' to create it"
+    fi
+
+    # File count checks (use first preset for multi-preset)
+    local preset_key="${preset%%,*}"
+    local exp_instr=3 exp_agents=5 exp_prompts=7 exp_skills=0
+    case "$preset_key" in
+        dotnet|typescript|python|java|go|azure-iac)
+            exp_instr=14; exp_agents=17; exp_prompts=9; exp_skills=8 ;;
+        custom)
+            exp_instr=3; exp_agents=5; exp_prompts=7; exp_skills=0 ;;
+    esac
+
+    if [ "$preset_key" != "unknown" ]; then
+        local instr_count=0 agent_count=0 prompt_count=0 skill_count=0
+
+        [ -d "$REPO_ROOT/.github/instructions" ] && instr_count=$(find "$REPO_ROOT/.github/instructions" -name "*.instructions.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+        [ -d "$REPO_ROOT/.github/agents" ]       && agent_count=$(find "$REPO_ROOT/.github/agents" -name "*.agent.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+        [ -d "$REPO_ROOT/.github/prompts" ]      && prompt_count=$(find "$REPO_ROOT/.github/prompts" -name "*.prompt.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+        [ -d "$REPO_ROOT/.github/skills" ]       && skill_count=$(find "$REPO_ROOT/.github/skills" -name "SKILL.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+
+        [ "$instr_count" -ge "$exp_instr" ] \
+            && doctor_pass "$instr_count instruction files (expected: >=$exp_instr for $preset_key)" \
+            || doctor_warn "$instr_count instruction files (expected: >=$exp_instr for $preset_key)" "Run 'pforge update' to get missing files"
+
+        [ "$agent_count" -ge "$exp_agents" ] \
+            && doctor_pass "$agent_count agent definitions (expected: >=$exp_agents for $preset_key)" \
+            || doctor_warn "$agent_count agent definitions (expected: >=$exp_agents for $preset_key)" "Run 'pforge update' to get missing agents"
+
+        [ "$prompt_count" -ge "$exp_prompts" ] \
+            && doctor_pass "$prompt_count prompt templates (expected: >=$exp_prompts for $preset_key)" \
+            || doctor_warn "$prompt_count prompt templates (expected: >=$exp_prompts for $preset_key)" "Run 'pforge update' to get missing prompts"
+
+        [ "$skill_count" -ge "$exp_skills" ] \
+            && doctor_pass "$skill_count skills (expected: >=$exp_skills for $preset_key)" \
+            || doctor_warn "$skill_count skills (expected: >=$exp_skills for $preset_key)" "Run 'pforge update' to get missing skills"
+    fi
+
+    echo ""
+
+    # ═══════════════════════════════════════════════════════════════
+    # 4. VERSION CURRENCY
+    # ═══════════════════════════════════════════════════════════════
+    echo "Version Currency:"
+
+    local source_version=""
+    local parent_dir
+    parent_dir="$(dirname "$REPO_ROOT")"
+    for candidate in "$parent_dir/plan-forge" "$parent_dir/Plan-Forge"; do
+        if [ -f "$candidate/VERSION" ]; then
+            source_version="$(cat "$candidate/VERSION" | tr -d '[:space:]')"
+            break
+        fi
+    done
+
+    if [ -n "$source_version" ]; then
+        if [ "$template_version" = "$source_version" ]; then
+            doctor_pass "Up to date (v$template_version)"
+        elif [ "$template_version" = "unknown" ]; then
+            doctor_warn "Cannot determine installed version (.forge.json missing)"
+        else
+            doctor_warn "Installed v$template_version — latest is v$source_version" "Run 'pforge update' to upgrade"
+        fi
+    else
+        doctor_pass "Installed v$template_version (source repo not found nearby — skipping currency check)"
+    fi
+
+    echo ""
+
+    # ═══════════════════════════════════════════════════════════════
+    # 5. COMMON PROBLEMS
+    # ═══════════════════════════════════════════════════════════════
+    echo "Common Problems:"
+
+    local problems_found=false
+
+    # 5a. Duplicate instruction files (case-insensitive)
+    if [ -d "$REPO_ROOT/.github/instructions" ]; then
+        local dupes
+        dupes="$(find "$REPO_ROOT/.github/instructions" -name "*.instructions.md" -type f -exec basename {} \; 2>/dev/null | tr '[:upper:]' '[:lower:]' | sort | uniq -d)"
+        if [ -n "$dupes" ]; then
+            doctor_fail "Duplicate instruction files detected: $dupes" "Remove duplicates from .github/instructions/"
+            problems_found=true
+        fi
+    fi
+
+    # 5b. Orphaned agents in AGENTS.md
+    local agents_md="$REPO_ROOT/AGENTS.md"
+    local agents_dir="$REPO_ROOT/.github/agents"
+    if [ -f "$agents_md" ] && [ -d "$agents_dir" ]; then
+        local referenced
+        referenced="$(grep -oE '[a-z0-9-]+\.agent\.md' "$agents_md" 2>/dev/null | sort -u)"
+        for ref in $referenced; do
+            if [ ! -f "$agents_dir/$ref" ]; then
+                doctor_warn "AGENTS.md references '$ref' but file not found in .github/agents/" "Remove from AGENTS.md or run 'pforge update'"
+                problems_found=true
+            fi
+        done
+    fi
+
+    # 5c. Instruction files missing applyTo
+    if [ -d "$REPO_ROOT/.github/instructions" ]; then
+        for f in "$REPO_ROOT/.github/instructions/"*.instructions.md; do
+            [ -f "$f" ] || continue
+            if head -5 "$f" | grep -q '^---' && ! grep -q 'applyTo' "$f"; then
+                local fname
+                fname="$(basename "$f")"
+                doctor_warn "$fname has frontmatter but no applyTo pattern" "Add 'applyTo: **' or a specific glob pattern"
+                problems_found=true
+            fi
+        done
+    fi
+
+    # 5d. Unresolved placeholders in copilot-instructions.md
+    if [ -f "$copilot_instr" ]; then
+        local ph_count=0
+        local ph_list=""
+        for ph in '<YOUR PROJECT NAME>' '<YOUR TECH STACK>' '<YOUR BUILD COMMAND>' '<YOUR TEST COMMAND>' '<YOUR LINT COMMAND>' '<YOUR DEV COMMAND>' '<DATE>'; do
+            if grep -qF "$ph" "$copilot_instr" 2>/dev/null; then
+                ph_count=$((ph_count + 1))
+                ph_list="${ph_list:+$ph_list, }$ph"
+            fi
+        done
+        if [ "$ph_count" -gt 0 ]; then
+            doctor_warn "copilot-instructions.md has $ph_count unresolved placeholder(s): $ph_list" "Edit .github/copilot-instructions.md and fill in your project details"
+            problems_found=true
+        fi
+    fi
+
+    # 5e. Roadmap missing
+    if [ ! -f "$REPO_ROOT/docs/plans/DEPLOYMENT-ROADMAP.md" ]; then
+        doctor_warn "DEPLOYMENT-ROADMAP.md not found" "Run 'pforge init' or create docs/plans/DEPLOYMENT-ROADMAP.md"
+        problems_found=true
+    fi
+
+    if [ "$problems_found" = false ]; then
+        doctor_pass "No common problems detected"
+    fi
+
+    # ═══════════════════════════════════════════════════════════════
+    # SUMMARY
+    # ═══════════════════════════════════════════════════════════════
+    echo ""
+    echo "────────────────────────────────────────────────────"
+    echo "  Results:  $d_pass passed  |  $d_fail failed  |  $d_warn warnings"
+    echo "────────────────────────────────────────────────────"
+
+    if [ "$d_fail" -gt 0 ]; then
+        echo ""
+        echo "Fix the $d_fail issue(s) above for the best Plan Forge experience."
+        exit 1
+    elif [ "$d_warn" -gt 0 ]; then
+        echo ""
+        echo "$d_warn warning(s) — review the suggestions above."
+        exit 0
+    else
+        echo ""
+        echo "Your forge is ready. Happy smithing!"
+        exit 0
+    fi
+}
+
 # ─── Command Router ────────────────────────────────────────────────────
 COMMAND="${1:-help}"
 shift 2>/dev/null || true
@@ -996,6 +1285,7 @@ case "$COMMAND" in
     diff)         cmd_diff "$@" ;;
     ext)          cmd_ext "$@" ;;
     update)       cmd_update "$@" ;;
+    smith)        cmd_smith ;;
     help|--help)  show_help ;;
     *)
         echo "ERROR: Unknown command '$COMMAND'" >&2


### PR DESCRIPTION
## Summary

Adds pforge smith — a forge-themed diagnostic command that inspects your environment, VS Code configuration, setup health, version currency, and common problems before you start building.

### Five Diagnostic Categories

| # | Category | Checks |
|---|---|---|
| 1 | **Environment** | git, VS Code CLI, PowerShell/bash version, GitHub CLI |
| 2 | **VS Code Config** | agent mode, parent repo customizations, prompt files |
| 3 | **Setup Health** | .forge.json, copilot-instructions.md, file counts per preset |
| 4 | **Version Currency** | installed templateVersion vs source VERSION |
| 5 | **Common Problems** | duplicates, orphaned agents, missing applyTo, unresolved placeholders |

Every failure includes a **FIX:** suggestion with the exact command or setting to resolve it.

### Cross-Platform Parity
- PowerShell: `pforge.ps1 smith`
- Bash: `pforge.sh smith`

### Documentation Updated
- CLI-GUIDE.md — full section with example output
- docs.html, index.html, faq.html — feature card + FAQ entry
- AGENT-SETUP.md, CUSTOMIZATION.md, README.md, ROADMAP.md

### Commits
1. \eat(cli)\: implementation (696 lines across both scripts)
2. \docs\: repo documentation updates (6 files)
3. \docs(site)\: HTML site feature card + FAQ