### PR TITLE
feat(ci): add plan-forge-validate GitHub Action

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@ Brief description of the changes.
 
 - [ ] I've tested with at least one preset (which? _______)
 - [ ] `validate-setup.ps1` / `validate-setup.sh` passes (or `pforge check`)
+- [ ] CI: Plan Forge Validate action passes (if configured)
 - [ ] New files follow existing naming conventions
 - [ ] Documentation updated (if applicable)
 - [ ] CHANGELOG.md updated (if user-facing change)

--- a/AGENT-SETUP.md
+++ b/AGENT-SETUP.md
@@ -91,6 +91,13 @@ Run the validation script to confirm everything landed correctly:
 
 All checks must pass before proceeding to plan hardening.
 
+**Optional: CI validation** — Add automated plan validation to your PR workflow:
+```yaml
+# .github/workflows/plan-forge-validate.yml
+- uses: srnichols/plan-forge-validate@v1
+```
+See [docs/plans/examples/plan-forge-validate.yml](docs/plans/examples/plan-forge-validate.yml) for the full workflow.
+
 ---
 
 ## Section 2: Brownfield Setup (Existing Project with Guardrails)

--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -731,6 +731,26 @@ pforge help              Show all commands
 
 ---
 
+## CI Validation (Optional)
+
+Add automated plan validation to your PR workflow:
+
+```yaml
+# .github/workflows/plan-forge-validate.yml
+name: Plan Forge Validate
+on: [pull_request]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: srnichols/plan-forge-validate@v1
+```
+
+This checks setup health, file counts, placeholders, orphans, and plan artifacts on every PR. See [docs/plans/examples/plan-forge-validate.yml](docs/plans/examples/plan-forge-validate.yml) for all options.
+
+---
+
 ## Removing Template Scaffolding
 
 After setup, you can safely delete these directories:

--- a/README.md
+++ b/README.md
@@ -550,6 +550,8 @@ plan-forge/
 ├── setup.sh                           ← Setup wizard (Bash, supports --auto-detect)
 ├── validate-setup.ps1                 ← Post-setup validator (PowerShell)
 ├── validate-setup.sh                  ← Post-setup validator (Bash)
+├── action.yml                         ← GitHub Action for CI plan validation
+├── scripts/validate-action.sh         ← CI validation script (used by action.yml)
 ├── CUSTOMIZATION.md                   ← How to adapt for your stack
 │
 ├── docs/
@@ -805,6 +807,29 @@ If you open a subfolder of a monorepo (not the repo root), Copilot won't find `.
 This tells Copilot to walk up to the `.git` root and discover all instruction files, prompts, agents, skills, and hooks from parent directories.
 
 **CLI in monorepos**: The `pforge` CLI auto-detects the repo root by walking up to the nearest `.git` directory. Run it from any subfolder — it will find `.forge.json`, `docs/plans/`, and `.github/` at the repo root automatically.
+
+---
+
+## CI/CD Integration
+
+Add automated plan validation to your PR workflow with the Plan Forge GitHub Action:
+
+```yaml
+# .github/workflows/plan-forge-validate.yml
+name: Plan Forge Validate
+on: [pull_request]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: srnichols/plan-forge-validate@v1
+        with:
+          sweep: true              # Run TODO/FIXME sweep
+          fail-on-warnings: false  # Warnings don't block merge
+```
+
+The action checks setup health, file counts, placeholders, orphaned agents, plan artifacts, and code cleanliness. See [docs/plans/examples/plan-forge-validate.yml](docs/plans/examples/plan-forge-validate.yml) for a complete example.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,7 +61,7 @@ See [CHANGELOG.md](CHANGELOG.md) for full release notes.
 These ideas are being evaluated but have no committed timeline:
 
 - **Web UI** for plan visualization and status tracking
-- **GitHub Action** for automated plan validation in CI
+- ~~**GitHub Action** for automated plan validation in CI~~ → shipped as `srnichols/plan-forge-validate` action
 - **MCP server** exposing Plan Forge operations as tools (plan, harden, review)
 - **Multi-model support** documentation (prompt variants for GPT-4, Gemini, etc.)
 - **Team dashboard** for multi-developer plan coordination

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,52 @@
+name: 'Plan Forge Validate'
+description: 'Validate Plan Forge setup, guardrail files, plan artifacts, and code cleanliness in CI'
+author: 'srnichols'
+branding:
+  icon: 'shield'
+  color: 'orange'
+
+inputs:
+  path:
+    description: 'Project directory to validate (defaults to repo root)'
+    required: false
+    default: '.'
+  fail-on-warnings:
+    description: 'Treat warnings as failures (exit code 1)'
+    required: false
+    default: 'false'
+  sweep:
+    description: 'Run completeness sweep for TODO/FIXME/stub markers'
+    required: false
+    default: 'true'
+  sweep-fail:
+    description: 'Fail the action if sweep finds markers (false = warn only)'
+    required: false
+    default: 'false'
+
+outputs:
+  passed:
+    description: 'Number of checks that passed'
+    value: ${{ steps.validate.outputs.passed }}
+  failed:
+    description: 'Number of checks that failed'
+    value: ${{ steps.validate.outputs.failed }}
+  warnings:
+    description: 'Number of warnings'
+    value: ${{ steps.validate.outputs.warnings }}
+  result:
+    description: 'Overall result: pass, warn, or fail'
+    value: ${{ steps.validate.outputs.result }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Plan Forge Validate
+      id: validate
+      shell: bash
+      env:
+        INPUT_PATH: ${{ inputs.path }}
+        INPUT_FAIL_ON_WARNINGS: ${{ inputs.fail-on-warnings }}
+        INPUT_SWEEP: ${{ inputs.sweep }}
+        INPUT_SWEEP_FAIL: ${{ inputs.sweep-fail }}
+      run: |
+        bash "${GITHUB_ACTION_PATH}/scripts/validate-action.sh"

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -536,6 +536,39 @@ The CLI handles **project management tasks** (setup, status, phases, branches, e
 
 ---
 
+## CI Integration
+
+Automate plan validation in your GitHub workflow with the Plan Forge Validate action:
+
+```yaml
+# .github/workflows/plan-forge-validate.yml
+name: Plan Forge Validate
+on: [pull_request]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: srnichols/plan-forge-validate@v1
+        with:
+          sweep: true
+          fail-on-warnings: false
+```
+
+The action runs the same checks as `pforge smith` + `pforge check` + `pforge sweep` — setup health, file counts, placeholders, orphans, plan artifacts, and code cleanliness. See [docs/plans/examples/plan-forge-validate.yml](../docs/plans/examples/plan-forge-validate.yml) for a complete example.
+
+**Inputs:**
+| Input | Default | Description |
+|-------|---------|-------------|
+| `path` | `.` | Project directory to validate |
+| `fail-on-warnings` | `false` | Treat warnings as failures |
+| `sweep` | `true` | Run completeness sweep |
+| `sweep-fail` | `false` | Fail on sweep markers |
+
+**Outputs:** `passed`, `failed`, `warnings`, `result` (pass/warn/fail) — usable in downstream steps.
+
+---
+
 ## Options
 
 | Flag | Applies To | Effect |

--- a/docs/QUICKSTART-WALKTHROUGH.md
+++ b/docs/QUICKSTART-WALKTHROUGH.md
@@ -185,4 +185,5 @@ Same pipeline, fewer copy-paste steps.
 - **Generate a Project Profile** — attach `.github/prompts/project-profile.prompt.md` to customize guardrails
 - **Define Project Principles** — attach `.github/prompts/project-principles.prompt.md` to declare non-negotiable rules
 - **Explore agents** — try the Security Reviewer or Architecture Reviewer on your codebase
+- **Add CI validation** — drop `uses: srnichols/plan-forge-validate@v1` into your PR workflow to automate quality gates
 - **Read the full guide** — [docs/COPILOT-VSCODE-GUIDE.md](COPILOT-VSCODE-GUIDE.md) for advanced tips

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -99,6 +99,10 @@
             <h3 class="font-semibold text-white group-hover:text-forge-400 transition-colors mb-1">CLI Guide</h3>
             <p class="text-sm text-slate-400">All <code class="text-forge-400">pforge</code> commands — init, check, smith, status, new-phase, branch, commit, sweep, diff, ext install.</p>
           </a>
+          <a href="https://github.com/srnichols/plan-forge/blob/master/action.yml" class="p-5 rounded-xl bg-slate-800/60 border border-slate-700/40 hover:border-forge-500/40 transition-colors group">
+            <h3 class="font-semibold text-white group-hover:text-forge-400 transition-colors mb-1">GitHub Action</h3>
+            <p class="text-sm text-slate-400">Automate plan validation in CI. Add <code class="text-forge-400">uses: srnichols/plan-forge-validate@v1</code> to your PR workflow.</p>
+          </a>
           <a href="https://github.com/srnichols/plan-forge/blob/master/docs/EXTENSIONS.md" class="p-5 rounded-xl bg-slate-800/60 border border-slate-700/40 hover:border-forge-500/40 transition-colors group">
             <h3 class="font-semibold text-white group-hover:text-forge-400 transition-colors mb-1">Extensions Guide</h3>
             <p class="text-sm text-slate-400">Create, distribute, and install reusable guardrail packages for your team.</p>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -295,6 +295,31 @@
         </div>
       </div>
 
+      <!-- CI/CD -->
+      <div class="faq-category">
+        <h2 class="text-xl font-bold text-white mb-5 flex items-center gap-3">
+          <span class="w-8 h-8 rounded-lg bg-forge-500/20 flex items-center justify-center text-forge-400 text-sm">🔄</span>
+          CI/CD
+        </h2>
+        <div class="space-y-3">
+          <details class="faq-item group rounded-xl bg-slate-800/60 border border-slate-700/40 overflow-hidden">
+            <summary class="flex items-center justify-between px-6 py-4 cursor-pointer hover:bg-slate-800/80 transition-colors">
+              <span class="text-sm font-medium text-white pr-4">How do I validate plans automatically on every PR?</span>
+              <svg class="w-4 h-4 text-slate-500 group-open:rotate-180 transition-transform shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+            </summary>
+            <div class="px-6 pb-5 text-sm text-slate-400 leading-relaxed border-t border-slate-700/30 pt-4">
+              <p class="mb-3">Add the <strong>Plan Forge Validate</strong> GitHub Action to your workflow:</p>
+              <pre class="bg-slate-900/60 rounded-lg p-4 text-xs text-forge-400 overflow-x-auto mb-3"><code>- uses: srnichols/plan-forge-validate@v1
+  with:
+    sweep: true              # Run TODO/FIXME sweep
+    fail-on-warnings: false  # Warnings don't block merge</code></pre>
+              <p class="mb-3">It checks six areas: setup health, file counts per preset, unresolved placeholders, orphaned agents, plan artifacts (scope contracts + slices), and a completeness sweep. Every failure shows exactly what's wrong.</p>
+              <p>The action has zero dependencies beyond bash and git, runs in ~5 seconds, and outputs <code class="text-forge-400">passed</code>, <code class="text-forge-400">failed</code>, <code class="text-forge-400">warnings</code>, and <code class="text-forge-400">result</code> for use in downstream steps.</p>
+            </div>
+          </details>
+        </div>
+      </div>
+
       <!-- Comparison -->
       <div class="faq-category">
         <h2 class="text-xl font-bold text-white mb-5 flex items-center gap-3">

--- a/docs/index.html
+++ b/docs/index.html
@@ -567,6 +567,14 @@
           </div>
         </div>
 
+        <!-- GitHub Action -->
+        <div class="p-8 rounded-2xl bg-slate-800/60 border border-slate-700/50">
+          <div class="w-12 h-12 rounded-xl bg-cyan-500/20 flex items-center justify-center text-2xl mb-4">🔄</div>
+          <h3 class="text-xl font-bold text-white mb-2">CI Validation Action</h3>
+          <p class="text-sm text-slate-400 mb-4">Drop one line into your GitHub workflow to validate plans on every PR — setup health, file counts, placeholders, orphans, plan artifacts, and code sweep.</p>
+          <pre class="bg-slate-900/60 rounded-lg p-3 text-xs text-forge-400 overflow-x-auto"><code>- uses: srnichols/plan-forge-validate@v1</code></pre>
+        </div>
+
       </div>
 
       <!-- What's the difference? -->

--- a/docs/plans/examples/plan-forge-validate.yml
+++ b/docs/plans/examples/plan-forge-validate.yml
@@ -1,0 +1,23 @@
+# Plan Forge Validate — Example Workflow
+# Copy this file to your repo's .github/workflows/ directory.
+# It validates Plan Forge setup and guardrails on every pull request.
+
+name: Plan Forge Validate
+on:
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  validate:
+    name: Validate Forge
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Plan Forge Validate
+        uses: srnichols/plan-forge-validate@v1
+        with:
+          # path: '.'              # Project directory (default: repo root)
+          # fail-on-warnings: false  # Treat warnings as failures
+          # sweep: true            # Run TODO/FIXME/stub sweep
+          # sweep-fail: false      # Fail on sweep markers (default: warn only)

--- a/scripts/validate-action.sh
+++ b/scripts/validate-action.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# Plan Forge Validate — GitHub Action Script
+# Validates Plan Forge setup, guardrail files, plan artifacts, and code cleanliness.
+set -uo pipefail
+
+PROJECT_DIR="${INPUT_PATH:-.}"
+FAIL_ON_WARNINGS="${INPUT_FAIL_ON_WARNINGS:-false}"
+RUN_SWEEP="${INPUT_SWEEP:-true}"
+SWEEP_FAIL="${INPUT_SWEEP_FAIL:-false}"
+
+PASS=0
+FAIL=0
+WARN=0
+
+# ─── Helpers ────────────────────────────────────────────────────────
+pass() { echo "  ✅ $1"; PASS=$((PASS + 1)); }
+fail() { echo "  ❌ $1"; FAIL=$((FAIL + 1)); }
+warn() { echo "  ⚠️  $1"; WARN=$((WARN + 1)); }
+
+echo ""
+echo "╔══════════════════════════════════════════════════════════════╗"
+echo "║       Plan Forge — Validate (CI)                             ║"
+echo "╚══════════════════════════════════════════════════════════════╝"
+echo ""
+echo "Project: $PROJECT_DIR"
+echo ""
+
+# ═══════════════════════════════════════════════════════════════════
+# 1. SETUP HEALTH
+# ═══════════════════════════════════════════════════════════════════
+echo "Setup Health:"
+
+PRESET="unknown"
+TEMPLATE_VERSION="unknown"
+
+CONFIG_PATH="$PROJECT_DIR/.forge.json"
+if [ -f "$CONFIG_PATH" ]; then
+    # Parse with grep/sed — no jq dependency
+    PRESET="$(grep -o '"preset"[^,}]*' "$CONFIG_PATH" | sed 's/"preset":\s*"//' | sed 's/"//' || echo "unknown")"
+    TEMPLATE_VERSION="$(grep -o '"templateVersion"[^,}]*' "$CONFIG_PATH" | sed 's/"templateVersion":\s*"//' | sed 's/"//' || echo "unknown")"
+    pass ".forge.json valid (preset: $PRESET, v$TEMPLATE_VERSION)"
+else
+    fail ".forge.json not found — run 'pforge init' to bootstrap"
+fi
+
+COPILOT_INSTR="$PROJECT_DIR/.github/copilot-instructions.md"
+if [ -f "$COPILOT_INSTR" ]; then
+    pass ".github/copilot-instructions.md exists"
+else
+    fail ".github/copilot-instructions.md missing"
+fi
+
+# Core guardrails
+ARCH_INSTR="$PROJECT_DIR/.github/instructions/architecture-principles.instructions.md"
+GIT_INSTR="$PROJECT_DIR/.github/instructions/git-workflow.instructions.md"
+if [ -f "$ARCH_INSTR" ] && [ -f "$GIT_INSTR" ]; then
+    pass "Core guardrail files present (architecture-principles, git-workflow)"
+else
+    fail "Missing core guardrail files"
+fi
+
+echo ""
+
+# ═══════════════════════════════════════════════════════════════════
+# 2. FILE COUNTS PER PRESET
+# ═══════════════════════════════════════════════════════════════════
+echo "File Counts:"
+
+PRESET_KEY="${PRESET%%,*}"  # First preset for multi-preset
+
+case "$PRESET_KEY" in
+    dotnet|typescript|python|java|go|azure-iac)
+        EXP_INSTR=14; EXP_AGENTS=17; EXP_PROMPTS=9; EXP_SKILLS=8 ;;
+    custom)
+        EXP_INSTR=3; EXP_AGENTS=5; EXP_PROMPTS=7; EXP_SKILLS=0 ;;
+    *)
+        EXP_INSTR=3; EXP_AGENTS=0; EXP_PROMPTS=0; EXP_SKILLS=0 ;;
+esac
+
+INSTR_COUNT=0; AGENT_COUNT=0; PROMPT_COUNT=0; SKILL_COUNT=0
+[ -d "$PROJECT_DIR/.github/instructions" ] && INSTR_COUNT=$(find "$PROJECT_DIR/.github/instructions" -name "*.instructions.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+[ -d "$PROJECT_DIR/.github/agents" ]       && AGENT_COUNT=$(find "$PROJECT_DIR/.github/agents" -name "*.agent.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+[ -d "$PROJECT_DIR/.github/prompts" ]      && PROMPT_COUNT=$(find "$PROJECT_DIR/.github/prompts" -name "*.prompt.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+[ -d "$PROJECT_DIR/.github/skills" ]       && SKILL_COUNT=$(find "$PROJECT_DIR/.github/skills" -name "SKILL.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+
+[ "$INSTR_COUNT" -ge "$EXP_INSTR" ] \
+    && pass "$INSTR_COUNT instruction files (expected: >=$EXP_INSTR for $PRESET_KEY)" \
+    || warn "$INSTR_COUNT instruction files (expected: >=$EXP_INSTR for $PRESET_KEY)"
+
+[ "$AGENT_COUNT" -ge "$EXP_AGENTS" ] \
+    && pass "$AGENT_COUNT agent definitions (expected: >=$EXP_AGENTS for $PRESET_KEY)" \
+    || warn "$AGENT_COUNT agent definitions (expected: >=$EXP_AGENTS for $PRESET_KEY)"
+
+[ "$PROMPT_COUNT" -ge "$EXP_PROMPTS" ] \
+    && pass "$PROMPT_COUNT prompt templates (expected: >=$EXP_PROMPTS for $PRESET_KEY)" \
+    || warn "$PROMPT_COUNT prompt templates (expected: >=$EXP_PROMPTS for $PRESET_KEY)"
+
+[ "$SKILL_COUNT" -ge "$EXP_SKILLS" ] \
+    && pass "$SKILL_COUNT skills (expected: >=$EXP_SKILLS for $PRESET_KEY)" \
+    || warn "$SKILL_COUNT skills (expected: >=$EXP_SKILLS for $PRESET_KEY)"
+
+echo ""
+
+# ═══════════════════════════════════════════════════════════════════
+# 3. PLACEHOLDER CHECK
+# ═══════════════════════════════════════════════════════════════════
+echo "Placeholder Check:"
+
+if [ -f "$COPILOT_INSTR" ]; then
+    PH_COUNT=0
+    PH_LIST=""
+    for ph in '<YOUR PROJECT NAME>' '<YOUR TECH STACK>' '<YOUR BUILD COMMAND>' '<YOUR TEST COMMAND>' '<YOUR LINT COMMAND>' '<YOUR DEV COMMAND>' '<DATE>'; do
+        if grep -qF "$ph" "$COPILOT_INSTR" 2>/dev/null; then
+            PH_COUNT=$((PH_COUNT + 1))
+            PH_LIST="${PH_LIST:+$PH_LIST, }$ph"
+        fi
+    done
+    if [ "$PH_COUNT" -gt 0 ]; then
+        fail "copilot-instructions.md has $PH_COUNT unresolved placeholder(s): $PH_LIST"
+    else
+        pass "No unresolved placeholders in copilot-instructions.md"
+    fi
+else
+    warn "copilot-instructions.md not found — skipping placeholder check"
+fi
+
+echo ""
+
+# ═══════════════════════════════════════════════════════════════════
+# 4. ORPHAN DETECTION
+# ═══════════════════════════════════════════════════════════════════
+echo "Orphan Detection:"
+
+AGENTS_MD="$PROJECT_DIR/AGENTS.md"
+AGENTS_DIR="$PROJECT_DIR/.github/agents"
+ORPHANS_FOUND=false
+
+if [ -f "$AGENTS_MD" ] && [ -d "$AGENTS_DIR" ]; then
+    REFERENCED=$(grep -oE '[a-z0-9-]+\.agent\.md' "$AGENTS_MD" 2>/dev/null | sort -u)
+    for ref in $REFERENCED; do
+        if [ ! -f "$AGENTS_DIR/$ref" ]; then
+            warn "AGENTS.md references '$ref' but file not found"
+            ORPHANS_FOUND=true
+        fi
+    done
+    if [ "$ORPHANS_FOUND" = false ]; then
+        pass "No orphaned agent references"
+    fi
+else
+    pass "Agent orphan check skipped (AGENTS.md or agents/ not present)"
+fi
+
+# Instruction files missing applyTo
+INSTR_DIR="$PROJECT_DIR/.github/instructions"
+APPLY_TO_ISSUES=false
+if [ -d "$INSTR_DIR" ]; then
+    for f in "$INSTR_DIR"/*.instructions.md; do
+        [ -f "$f" ] || continue
+        if head -5 "$f" | grep -q '^---' && ! grep -q 'applyTo' "$f"; then
+            FNAME="$(basename "$f")"
+            warn "$FNAME has frontmatter but no applyTo pattern"
+            APPLY_TO_ISSUES=true
+        fi
+    done
+    if [ "$APPLY_TO_ISSUES" = false ]; then
+        pass "All instruction files have applyTo patterns"
+    fi
+fi
+
+echo ""
+
+# ═══════════════════════════════════════════════════════════════════
+# 5. PLAN ARTIFACT CHECK
+# ═══════════════════════════════════════════════════════════════════
+echo "Plan Artifacts:"
+
+PLANS_DIR="$PROJECT_DIR/docs/plans"
+ROADMAP="$PLANS_DIR/DEPLOYMENT-ROADMAP.md"
+
+if [ -f "$ROADMAP" ]; then
+    pass "DEPLOYMENT-ROADMAP.md exists"
+else
+    warn "DEPLOYMENT-ROADMAP.md not found"
+fi
+
+# Check active plans for required sections
+if [ -d "$PLANS_DIR" ]; then
+    PLAN_COUNT=$(find "$PLANS_DIR" -name "Phase-*-PLAN.md" -type f 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$PLAN_COUNT" -gt 0 ]; then
+        PLANS_OK=0
+        PLANS_MISSING=0
+        for plan in "$PLANS_DIR"/Phase-*-PLAN.md; do
+            [ -f "$plan" ] || continue
+            PLAN_NAME="$(basename "$plan")"
+            # Check for scope contract and slices
+            HAS_SCOPE=$(grep -c '### In Scope\|### Scope Contract\|## Scope' "$plan" 2>/dev/null || echo 0)
+            HAS_SLICES=$(grep -c '### Slice\|## Execution Slices\|## Slices' "$plan" 2>/dev/null || echo 0)
+            if [ "$HAS_SCOPE" -gt 0 ] && [ "$HAS_SLICES" -gt 0 ]; then
+                PLANS_OK=$((PLANS_OK + 1))
+            else
+                MISSING_PARTS=""
+                [ "$HAS_SCOPE" -eq 0 ] && MISSING_PARTS="scope contract"
+                [ "$HAS_SLICES" -eq 0 ] && MISSING_PARTS="${MISSING_PARTS:+$MISSING_PARTS, }execution slices"
+                warn "$PLAN_NAME missing: $MISSING_PARTS"
+                PLANS_MISSING=$((PLANS_MISSING + 1))
+            fi
+        done
+        if [ "$PLANS_MISSING" -eq 0 ]; then
+            pass "$PLAN_COUNT plan(s) — all have scope contracts and slices"
+        fi
+    else
+        pass "No phase plans yet (OK for new projects)"
+    fi
+fi
+
+echo ""
+
+# ═══════════════════════════════════════════════════════════════════
+# 6. COMPLETENESS SWEEP (optional)
+# ═══════════════════════════════════════════════════════════════════
+if [ "$RUN_SWEEP" = "true" ]; then
+    echo "Completeness Sweep:"
+
+    SWEEP_PATTERNS='TODO|FIXME|HACK|will be replaced|placeholder|stub|mock data'
+    CODE_EXTENSIONS="cs ts tsx js jsx py go java kt rb rs sql sh ps1"
+
+    SWEEP_TOTAL=0
+    for ext in $CODE_EXTENSIONS; do
+        while IFS= read -r finding; do
+            if [ -n "$finding" ]; then
+                echo "  $finding"
+                SWEEP_TOTAL=$((SWEEP_TOTAL + 1))
+            fi
+        done < <(find "$PROJECT_DIR" -name "*.$ext" -type f \
+            ! -path '*/node_modules/*' ! -path '*/.git/*' ! -path '*/bin/*' \
+            ! -path '*/obj/*' ! -path '*/dist/*' ! -path '*/vendor/*' \
+            ! -path '*/__pycache__/*' ! -path '*/plan-forge/*' \
+            -exec grep -Hni -E "$SWEEP_PATTERNS" {} \; 2>/dev/null | head -50)
+    done
+
+    if [ "$SWEEP_TOTAL" -eq 0 ]; then
+        pass "Sweep clean — zero deferred-work markers"
+    else
+        if [ "$SWEEP_FAIL" = "true" ]; then
+            fail "Found $SWEEP_TOTAL deferred-work marker(s)"
+        else
+            warn "Found $SWEEP_TOTAL deferred-work marker(s)"
+        fi
+    fi
+
+    echo ""
+fi
+
+# ═══════════════════════════════════════════════════════════════════
+# SUMMARY
+# ═══════════════════════════════════════════════════════════════════
+echo "────────────────────────────────────────────────────"
+echo "  Results:  $PASS passed  |  $FAIL failed  |  $WARN warnings"
+echo "────────────────────────────────────────────────────"
+
+# Set outputs for GitHub Actions
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "passed=$PASS" >> "$GITHUB_OUTPUT"
+    echo "failed=$FAIL" >> "$GITHUB_OUTPUT"
+    echo "warnings=$WARN" >> "$GITHUB_OUTPUT"
+fi
+
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "❌ VALIDATION FAILED — $FAIL issue(s) must be fixed."
+    [ -n "${GITHUB_OUTPUT:-}" ] && echo "result=fail" >> "$GITHUB_OUTPUT"
+    exit 1
+elif [ "$WARN" -gt 0 ] && [ "$FAIL_ON_WARNINGS" = "true" ]; then
+    echo ""
+    echo "⚠️  VALIDATION FAILED (fail-on-warnings enabled) — $WARN warning(s)."
+    [ -n "${GITHUB_OUTPUT:-}" ] && echo "result=fail" >> "$GITHUB_OUTPUT"
+    exit 1
+elif [ "$WARN" -gt 0 ]; then
+    echo ""
+    echo "⚠️  Passed with $WARN warning(s)."
+    [ -n "${GITHUB_OUTPUT:-}" ] && echo "result=warn" >> "$GITHUB_OUTPUT"
+    exit 0
+else
+    echo ""
+    echo "✅ All checks passed. Your forge is solid."
+    [ -n "${GITHUB_OUTPUT:-}" ] && echo "result=pass" >> "$GITHUB_OUTPUT"
+    exit 0
+fi


### PR DESCRIPTION
## Summary

Adds a **reusable GitHub Action** that teams can drop into any repo to validate Plan Forge setup on every PR.

### Usage
\\\yaml
- uses: srnichols/plan-forge-validate@v1
  with:
    fail-on-warnings: false
    sweep: true
\\\

### Six Validation Categories
1. **Setup health** — .forge.json, copilot-instructions.md, core guardrails
2. **File counts** — instruction/agent/prompt/skill counts vs preset minimums
3. **Placeholder check** — no unresolved \<YOUR ...>\ markers
4. **Orphan detection** — AGENTS.md refs match actual files + applyTo patterns
5. **Plan artifacts** — scope contracts and execution slices in phase plans
6. **Completeness sweep** — configurable TODO/FIXME/stub scan

### Outputs
\passed\, \ailed\, \warnings\, \esult\ (pass/warn/fail) — usable in downstream steps.

### Files
- \ction.yml\ — composite action definition
- \scripts/validate-action.sh\ — validation logic (no dependencies beyond bash + git)
- \docs/plans/examples/plan-forge-validate.yml\ — copy-paste example workflow
- \ROADMAP.md\ — marked GitHub Action item as shipped