### PR TITLE
feat: extension ecosystem + Spec Kit bridge — catalog, search, add, import

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -61,6 +61,10 @@ pforge check
 
 # Multi-agent: setup generates native files for Claude, Cursor, Codex
 # setup.ps1 -Agent claude | setup.sh --agent claude
+
+# Browse and install community extensions
+pforge ext search
+pforge ext add <name>
 ```
 
 ---

--- a/.github/prompts/step0-specify-feature.prompt.md
+++ b/.github/prompts/step0-specify-feature.prompt.md
@@ -19,9 +19,48 @@ Your job is to help me describe WHAT I want to build and WHY — not HOW to buil
 
 ---
 
-### FIRST: Do you have an existing document?
+### FIRST: Check for Spec Kit Artifacts
 
-Before starting the interview, ask:
+Before asking any questions, scan the project for Spec Kit artifacts:
+
+1. Check if `specs/` directory exists (Spec Kit feature directory)
+2. Check if `memory/constitution.md` exists (Spec Kit project constitution)
+3. Check if any `specs/*/spec.md` or `specs/*/plan.md` files exist
+
+**If Spec Kit artifacts are found:**
+
+> "I found Spec Kit artifacts in this project:
+> - `specs/<feature>/spec.md` — feature specification
+> - `specs/<feature>/plan.md` — implementation plan
+> - `memory/constitution.md` — project constitution
+>
+> Plan Forge can import these directly:
+> 1. **Import spec** → Skip the interview, map spec.md sections to Plan Forge format
+> 2. **Import plan** → Convert plan.md into a hardened execution contract (Phase Plan)
+> 3. **Import constitution** → Convert to `docs/plans/PROJECT-PRINCIPLES.md`
+> 4. **Start fresh** → Ignore Spec Kit files and run the full interview
+>
+> Which would you like?"
+
+**If the user chooses to import:**
+
+1. Read the Spec Kit `spec.md` and map its content to the 6 sections below
+2. Read `plan.md` (if it exists) and extract technology choices, architecture decisions, and task breakdown
+3. Read `constitution.md` (if it exists) and map principles to Plan Forge's `PROJECT-PRINCIPLES.md` format
+4. Show a coverage summary and fill in any gaps with targeted questions
+5. Generate the Plan Forge Phase Plan with a `### Specification Source` section:
+   ```markdown
+   ### Specification Source
+   - Imported from: Spec Kit (`specs/<feature>/spec.md`)
+   - Plan source: `specs/<feature>/plan.md`
+   - Constitution: `memory/constitution.md`
+   ```
+
+**If no Spec Kit artifacts found** — continue to the document check below.
+
+---
+
+### NEXT: Do you have an existing document?
 
 > "Do you have an existing document, spec, PRD, or notes you'd like to use as a starting point? (file path, URL, or 'no')"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   - Codex CLI: generates `.agents/skills/planforge-*/SKILL.md`
 - `.forge.json` now records configured agents in an `agents` field
 - `pforge smith` detects and validates agent-specific file paths
+- **Extension ecosystem** — `pforge ext search`, `pforge ext add <name>`, `pforge ext info <name>` commands with `extensions/catalog.json` community catalog (Spec Kit catalog-compatible format)
 - **Spec Kit comparison FAQ** — Honest side-by-side guidance on when to use Spec Kit vs Plan Forge
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Open an issue with the `enhancement` label. Describe the problem you're solving,
 | Contribution | Where | Guidelines |
 |-------------|-------|-----------|
 | **New tech preset** | `presets/<stack>/` | See CUSTOMIZATION.md → "Adding a New Tech Preset" |
-| **New extension** | `.forge/extensions/` | See docs/EXTENSIONS.md → "Creating an Extension" |
+| **New extension** | `.forge/extensions/` | See [docs/EXTENSIONS.md](docs/EXTENSIONS.md) + [extensions/PUBLISHING.md](extensions/PUBLISHING.md) |
 | **Instruction file improvements** | `presets/<stack>/.github/instructions/` | Keep under 150 lines, include `applyTo` frontmatter |
 | **Prompt template improvements** | `presets/<stack>/.github/prompts/` | Include stack-specific code examples |
 | **Documentation fixes** | `docs/`, `README.md`, etc. | Fix typos, clarify confusing sections, add examples |

--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -725,7 +725,10 @@ pforge sweep             Scan code for TODO/FIXME/stub markers (completeness che
 pforge diff <plan>       Compare changed files against plan's Scope Contract
 pforge commit <plan> <N> Commit with conventional message from slice goal
 pforge phase-status <plan> <status>  Update roadmap (planned|in-progress|complete|paused)
-pforge ext install <p>   Install an extension
+pforge ext search [q]    Search the community extension catalog
+pforge ext add <name>    Download and install from catalog
+pforge ext info <name>   Show extension details
+pforge ext install <p>   Install extension from local path
 pforge ext list          List installed extensions
 pforge ext remove <name> Remove an extension
 pforge help              Show all commands

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,10 +44,12 @@ See [CHANGELOG.md](CHANGELOG.md) for full release notes.
 - **Shipped**: Claude Code, Cursor, Codex CLI via `-Agent` / `--agent` parameter
 
 ### v1.7 — Community Extension Ecosystem
-- `pforge extension search` — browse and install community extensions from a catalog
-- `pforge extension publish` — package and submit extensions to the community catalog
-- Community preset framework — let contributors override templates/commands without forking
-- Extension categories: `docs`, `code`, `process`, `integration`, `visibility`
+- ~~`pforge extension search` — browse and install community extensions from a catalog~~
+- ~~`pforge extension publish` — package and submit extensions to the community catalog~~
+- ~~Community preset framework — let contributors override templates/commands without forking~~
+- ~~Extension categories: `docs`, `code`, `process`, `integration`, `visibility`~~
+- **Shipped**: `pforge ext search/add/info` + `extensions/catalog.json` (Spec Kit catalog-compatible format)
+- Dual-publish to Spec Kit catalog (deferred — needs community traction first)
 - Extension website or registry for discoverability
 
 ### v1.8 — Specification Interoperability

--- a/docs/CLI-GUIDE.md
+++ b/docs/CLI-GUIDE.md
@@ -291,6 +291,64 @@ DRIFT DETECTED — 1 forbidden file(s) touched.
 
 ---
 
+### `pforge ext search [query]`
+
+Browse the community extension catalog. Shows all extensions, or filter by keyword.
+
+```powershell
+# PowerShell
+.\pforge.ps1 ext search              # Show all extensions
+.\pforge.ps1 ext search saas         # Filter by keyword
+.\pforge.ps1 ext search integration  # Filter by category
+```
+
+```bash
+# Bash
+./pforge.sh ext search
+./pforge.sh ext search compliance
+```
+
+Fetches from the local `extensions/catalog.json` first, falls back to GitHub. Extensions marked with `speckit_compatible` work in both Plan Forge and Spec Kit.
+
+---
+
+### `pforge ext add <name>`
+
+Download and install an extension from the community catalog in one step.
+
+```powershell
+# PowerShell
+.\pforge.ps1 ext add saas-multi-tenancy
+.\pforge.ps1 ext add plan-forge-memory
+```
+
+```bash
+# Bash
+./pforge.sh ext add azure-infrastructure
+```
+
+Downloads the extension ZIP from GitHub, extracts the relevant subfolder, and delegates to `ext install`. No manual cloning needed.
+
+---
+
+### `pforge ext info <name>`
+
+Show detailed information about a catalog extension before installing.
+
+```powershell
+# PowerShell
+.\pforge.ps1 ext info plan-forge-memory
+```
+
+```bash
+# Bash
+./pforge.sh ext info saas-multi-tenancy
+```
+
+Shows: name, version, author, category, provides (instructions/agents/prompts/skills), tags, Spec Kit compatibility, and install command.
+
+---
+
 ### `pforge ext install <path>`
 
 Install an extension from a local path.

--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -61,6 +61,29 @@ No runtime, no dependencies, no build step — just folders you copy.
 pforge ext install .forge/extensions/healthcare-compliance
 ```
 
+## Searching & Installing from the Community Catalog
+
+Browse extensions without leaving the terminal:
+
+```bash
+pforge ext search                    # Show all available extensions
+pforge ext search saas               # Filter by keyword
+pforge ext search integration        # Filter by category
+```
+
+Install directly from the catalog (downloads + installs in one step):
+
+```bash
+pforge ext add saas-multi-tenancy    # Download and install
+pforge ext info plan-forge-memory    # Show details before installing
+```
+
+The catalog is stored in `extensions/catalog.json` (fetches from GitHub if not local). Extensions marked with `speckit_compatible: true` also work as Spec Kit extensions.
+
+### Publishing Your Extension
+
+See [extensions/PUBLISHING.md](../extensions/PUBLISHING.md) for how to submit your extension to the community catalog.
+
 ## Creating an Extension
 
 1. Create a folder with the extension name

--- a/docs/QUICKSTART-WALKTHROUGH.md
+++ b/docs/QUICKSTART-WALKTHROUGH.md
@@ -187,5 +187,6 @@ Same pipeline, fewer copy-paste steps.
 - **Generate a Project Profile** — attach `.github/prompts/project-profile.prompt.md` to customize guardrails
 - **Define Project Principles** — attach `.github/prompts/project-principles.prompt.md` to declare non-negotiable rules
 - **Explore agents** — try the Security Reviewer or Architecture Reviewer on your codebase
+- **Browse extensions** — run `pforge ext search` to discover community guardrails (compliance, multi-tenancy, memory, etc.)
 - **Add CI validation** — drop `uses: srnichols/plan-forge-validate@v1` into your PR workflow to automate quality gates
 - **Read the full guide** — [docs/COPILOT-VSCODE-GUIDE.md](COPILOT-VSCODE-GUIDE.md) for advanced tips

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -287,6 +287,16 @@
 
           <details class="faq-item group rounded-xl bg-slate-800/60 border border-slate-700/40 overflow-hidden">
             <summary class="flex items-center justify-between px-6 py-4 cursor-pointer hover:bg-slate-800/80 transition-colors">
+              <span class="text-sm font-medium text-white pr-4">Can I browse and install extensions from a catalog?</span>
+              <svg class="w-4 h-4 text-slate-500 group-open:rotate-180 transition-transform shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+            </summary>
+            <div class="px-6 pb-5 text-sm text-slate-400 leading-relaxed border-t border-slate-700/30 pt-4">
+              Yes. Run <code class="text-forge-400">pforge ext search</code> to browse the community catalog, <code class="text-forge-400">pforge ext info &lt;name&gt;</code> for details, and <code class="text-forge-400">pforge ext add &lt;name&gt;</code> to download and install in one step. The catalog uses a Spec Kit-compatible format — extensions marked <code class="text-forge-400">speckit_compatible</code> work in both tools.
+            </div>
+          </details>
+
+          <details class="faq-item group rounded-xl bg-slate-800/60 border border-slate-700/40 overflow-hidden">
+            <summary class="flex items-center justify-between px-6 py-4 cursor-pointer hover:bg-slate-800/80 transition-colors">
               <span class="text-sm font-medium text-white pr-4">Does Plan Forge support compliance requirements (SOC2, GDPR, HIPAA)?</span>
               <svg class="w-4 h-4 text-slate-500 group-open:rotate-180 transition-transform shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
             </summary>

--- a/extensions/PUBLISHING.md
+++ b/extensions/PUBLISHING.md
@@ -1,0 +1,89 @@
+# Extension Publishing Guide
+
+> How to add your extension to the Plan Forge community catalog.
+
+## Prerequisites
+
+- A working Plan Forge extension with `extension.json`
+- A public GitHub repository hosting the extension
+- MIT license (or compatible open-source license)
+
+## Steps
+
+### 1. Create Your Extension
+
+Follow the format in [docs/EXTENSIONS.md](docs/EXTENSIONS.md):
+
+```
+your-extension/
+├── extension.json           ← Metadata (name, version, files)
+├── instructions/            ← .instructions.md files
+├── agents/                  ← .agent.md files
+├── prompts/                 ← .prompt.md files
+└── README.md                ← Usage documentation
+```
+
+### 2. Add a Catalog Entry
+
+Fork `srnichols/plan-forge` and edit `extensions/catalog.json`. Add your extension to the `extensions` object:
+
+```json
+"your-extension-id": {
+  "name": "Your Extension Name",
+  "id": "your-extension-id",
+  "description": "One-line description of what it does.",
+  "author": "your-github-username",
+  "version": "1.0.0",
+  "download_url": "https://github.com/you/your-extension/archive/refs/tags/v1.0.0.zip",
+  "repository": "https://github.com/you/your-extension",
+  "license": "MIT",
+  "category": "code",
+  "effect": "Read+Write",
+  "requires": {
+    "planforge_version": ">=1.2.0"
+  },
+  "provides": {
+    "instructions": 2,
+    "agents": 1,
+    "prompts": 0,
+    "skills": 0
+  },
+  "tags": ["your", "tags", "here"],
+  "speckit_compatible": false,
+  "verified": false,
+  "created_at": "2026-01-01T00:00:00Z",
+  "updated_at": "2026-01-01T00:00:00Z"
+}
+```
+
+### 3. Submit a Pull Request
+
+Open a PR to `srnichols/plan-forge` with:
+- Title: `feat(catalog): add <your-extension-name>`
+- Only modify `extensions/catalog.json`
+- Link to your extension's repo in the PR description
+
+### Categories
+
+| Category | When to Use |
+|----------|------------|
+| `code` | Reviews, validates, or modifies source code |
+| `docs` | Reads, validates, or generates spec/plan artifacts |
+| `process` | Orchestrates workflow across phases |
+| `integration` | Syncs with external platforms (Jira, Azure DevOps, etc.) |
+| `visibility` | Reports on project health or progress |
+
+### Effect
+
+| Effect | Meaning |
+|--------|---------|
+| `Read-only` | Produces reports without modifying files |
+| `Read+Write` | Modifies files, creates artifacts, or updates specs |
+
+### Spec Kit Compatibility
+
+If your extension also works as a Spec Kit extension, set `"speckit_compatible": true`. This helps users who use both tools discover shared extensions.
+
+### Verification
+
+Extensions submitted by the Plan Forge maintainers are marked `"verified": true`. Community extensions start as `"verified": false` — maintainers may verify after review.

--- a/extensions/catalog.json
+++ b/extensions/catalog.json
@@ -1,0 +1,89 @@
+{
+  "schema_version": "1.0",
+  "updated_at": "2026-04-03T00:00:00Z",
+  "catalog_url": "https://raw.githubusercontent.com/srnichols/plan-forge/master/extensions/catalog.json",
+  "speckit_compatible": true,
+  "extensions": {
+    "saas-multi-tenancy": {
+      "name": "SaaS Multi-Tenancy",
+      "id": "saas-multi-tenancy",
+      "description": "RLS policies, tenant isolation middleware, cross-tenant prevention guardrails, and a tenant isolation reviewer agent.",
+      "author": "srnichols",
+      "version": "1.0.0",
+      "download_url": "https://github.com/srnichols/plan-forge/archive/refs/heads/master.zip",
+      "repository": "https://github.com/srnichols/plan-forge",
+      "path_in_repo": "docs/plans/examples/extensions/saas-multi-tenancy",
+      "license": "MIT",
+      "category": "code",
+      "effect": "Read+Write",
+      "requires": {
+        "planforge_version": ">=1.2.0"
+      },
+      "provides": {
+        "instructions": 0,
+        "agents": 1,
+        "prompts": 1,
+        "skills": 0
+      },
+      "tags": ["multi-tenancy", "saas", "rls", "tenant-isolation", "security"],
+      "speckit_compatible": false,
+      "verified": true,
+      "created_at": "2026-04-01T00:00:00Z",
+      "updated_at": "2026-04-03T00:00:00Z"
+    },
+    "azure-infrastructure": {
+      "name": "Azure Infrastructure",
+      "id": "azure-infrastructure",
+      "description": "Bicep, Terraform, and azd guardrails for mixed app+infra repos. Includes IaC reviewer agent and CAF naming conventions.",
+      "author": "srnichols",
+      "version": "1.0.0",
+      "download_url": "https://github.com/srnichols/plan-forge/archive/refs/heads/master.zip",
+      "repository": "https://github.com/srnichols/plan-forge",
+      "path_in_repo": "docs/plans/examples/extensions/azure-infrastructure",
+      "license": "MIT",
+      "category": "code",
+      "effect": "Read+Write",
+      "requires": {
+        "planforge_version": ">=1.2.0"
+      },
+      "provides": {
+        "instructions": 5,
+        "agents": 1,
+        "prompts": 3,
+        "skills": 0
+      },
+      "tags": ["azure", "bicep", "terraform", "azd", "infrastructure", "iac"],
+      "speckit_compatible": false,
+      "verified": true,
+      "created_at": "2026-04-01T00:00:00Z",
+      "updated_at": "2026-04-03T00:00:00Z"
+    },
+    "plan-forge-memory": {
+      "name": "Plan Forge Memory (OpenBrain)",
+      "id": "plan-forge-memory",
+      "description": "Persistent semantic memory via OpenBrain MCP server. Captures decisions, patterns, and postmortems across sessions. 106 files with search/capture hooks.",
+      "author": "srnichols",
+      "version": "1.0.0",
+      "download_url": "https://github.com/srnichols/plan-forge/archive/refs/heads/master.zip",
+      "repository": "https://github.com/srnichols/plan-forge",
+      "path_in_repo": "docs/plans/examples/extensions/plan-forge-memory",
+      "license": "MIT",
+      "category": "integration",
+      "effect": "Read+Write",
+      "requires": {
+        "planforge_version": ">=1.2.0"
+      },
+      "provides": {
+        "instructions": 1,
+        "agents": 1,
+        "prompts": 2,
+        "skills": 0
+      },
+      "tags": ["memory", "openbrain", "mcp", "semantic-search", "decisions", "persistence"],
+      "speckit_compatible": false,
+      "verified": true,
+      "created_at": "2026-04-01T00:00:00Z",
+      "updated_at": "2026-04-03T00:00:00Z"
+    }
+  }
+}

--- a/pforge.ps1
+++ b/pforge.ps1
@@ -424,7 +424,10 @@ function Invoke-PhaseStatus {
 function Invoke-Ext {
     if (-not $Arguments -or $Arguments.Count -eq 0) {
         Write-Host "Extension commands:" -ForegroundColor Cyan
-        Write-Host "  ext install <path>  Install extension from path"
+        Write-Host "  ext search [query]  Search the community catalog"
+        Write-Host "  ext add <name>      Download and install from catalog"
+        Write-Host "  ext info <name>     Show extension details"
+        Write-Host "  ext install <path>  Install extension from local path"
         Write-Host "  ext list            List installed extensions"
         Write-Host "  ext remove <name>   Remove an installed extension"
         return
@@ -434,14 +437,214 @@ function Invoke-Ext {
     $extArgs = if ($Arguments.Count -gt 1) { $Arguments[1..($Arguments.Count - 1)] } else { @() }
 
     switch ($subCmd) {
+        'search'  { Invoke-ExtSearch $extArgs }
+        'add'     { Invoke-ExtAdd $extArgs }
+        'info'    { Invoke-ExtInfo $extArgs }
         'install' { Invoke-ExtInstall $extArgs }
         'list'    { Invoke-ExtList }
         'remove'  { Invoke-ExtRemove $extArgs }
         default   {
             Write-Host "ERROR: Unknown ext command: $subCmd" -ForegroundColor Red
-            Write-Host "  Available: install, list, remove" -ForegroundColor Yellow
+            Write-Host "  Available: search, add, info, install, list, remove" -ForegroundColor Yellow
         }
     }
+}
+
+# ─── Catalog Helpers ───────────────────────────────────────────────────
+$script:CatalogUrl = "https://raw.githubusercontent.com/srnichols/plan-forge/master/extensions/catalog.json"
+
+function Get-ExtCatalog {
+    # Try local catalog first, then remote
+    $localCatalog = Join-Path $RepoRoot "extensions/catalog.json"
+    if (Test-Path $localCatalog) {
+        return Get-Content $localCatalog -Raw | ConvertFrom-Json
+    }
+    try {
+        $response = Invoke-RestMethod -Uri $script:CatalogUrl -TimeoutSec 10
+        return $response
+    }
+    catch {
+        Write-Host "ERROR: Could not fetch extension catalog." -ForegroundColor Red
+        Write-Host "  Check your internet connection or try again later." -ForegroundColor Yellow
+        return $null
+    }
+}
+
+function Invoke-ExtSearch([string[]]$args_) {
+    Write-ManualSteps "ext search" @(
+        "Fetch the community catalog from GitHub"
+        "Filter by query (or show all)"
+        "Display matching extensions"
+    )
+
+    $query = if ($args_ -and $args_.Count -gt 0) { $args_ -join ' ' } else { '' }
+    $catalog = Get-ExtCatalog
+    if (-not $catalog) { return }
+
+    $extensions = $catalog.extensions.PSObject.Properties | ForEach-Object { $_.Value }
+
+    if ($query) {
+        $q = $query.ToLower()
+        $extensions = $extensions | Where-Object {
+            $_.name.ToLower().Contains($q) -or
+            $_.description.ToLower().Contains($q) -or
+            ($_.tags -and ($_.tags -join ',').ToLower().Contains($q)) -or
+            ($_.category -and $_.category.ToLower().Contains($q))
+        }
+    }
+
+    if ($extensions.Count -eq 0) {
+        Write-Host "No extensions found$(if ($query) { " matching '$query'" })." -ForegroundColor Yellow
+        return
+    }
+
+    Write-Host ""
+    Write-Host "Plan Forge Extension Catalog$(if ($query) { " — matching '$query'" }):" -ForegroundColor Cyan
+    Write-Host "───────────────────────────────────────────────────────" -ForegroundColor DarkGray
+
+    foreach ($ext in $extensions) {
+        $compat = if ($ext.speckit_compatible -eq $true) { " [Spec Kit Compatible]" } else { "" }
+        $verified = if ($ext.verified -eq $true) { "✅" } else { "  " }
+        Write-Host "  $verified $($ext.id)" -ForegroundColor White -NoNewline
+        Write-Host "  v$($ext.version)" -ForegroundColor DarkGray -NoNewline
+        Write-Host "  [$($ext.category)]" -ForegroundColor DarkCyan -NoNewline
+        Write-Host "$compat" -ForegroundColor Green
+        Write-Host "     $($ext.description)" -ForegroundColor Gray
+    }
+
+    Write-Host ""
+    Write-Host "Use 'pforge ext info <name>' for details, 'pforge ext add <name>' to install." -ForegroundColor DarkGray
+}
+
+function Invoke-ExtAdd([string[]]$args_) {
+    if (-not $args_ -or $args_.Count -eq 0) {
+        Write-Host "ERROR: Extension name required." -ForegroundColor Red
+        Write-Host "  Usage: pforge ext add <name>" -ForegroundColor Yellow
+        Write-Host "  Browse: pforge ext search" -ForegroundColor Yellow
+        exit 1
+    }
+
+    $extName = $args_[0]
+    $catalog = Get-ExtCatalog
+    if (-not $catalog) { return }
+
+    $ext = $catalog.extensions.PSObject.Properties[$extName]
+    if (-not $ext) {
+        Write-Host "ERROR: Extension '$extName' not found in catalog." -ForegroundColor Red
+        Write-Host "  Run 'pforge ext search' to see available extensions." -ForegroundColor Yellow
+        exit 1
+    }
+    $ext = $ext.Value
+
+    Write-Host ""
+    Write-Host "Installing: $($ext.name) v$($ext.version)" -ForegroundColor Cyan
+    Write-Host "  $($ext.description)" -ForegroundColor Gray
+    Write-Host ""
+
+    # Download
+    $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "planforge-ext-$extName-$(Get-Date -Format 'yyyyMMddHHmmss')"
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+
+    try {
+        if ($ext.path_in_repo) {
+            # Clone just the needed path via sparse checkout or download ZIP + extract subfolder
+            $zipUrl = $ext.download_url
+            $zipFile = Join-Path $tempDir "repo.zip"
+            Write-Host "  Downloading from $($ext.repository)..." -ForegroundColor DarkGray
+            Invoke-WebRequest -Uri $zipUrl -OutFile $zipFile -UseBasicParsing
+            Expand-Archive -Path $zipFile -DestinationPath $tempDir -Force
+
+            # Find the extracted path (ZIP contains repo-name-branch/ prefix)
+            $extractedDirs = Get-ChildItem -Path $tempDir -Directory | Where-Object { $_.Name -ne '__MACOSX' }
+            $repoRoot = $extractedDirs | Select-Object -First 1
+            $extSourcePath = Join-Path $repoRoot.FullName $ext.path_in_repo
+
+            if (-not (Test-Path $extSourcePath)) {
+                Write-Host "ERROR: Path '$($ext.path_in_repo)' not found in downloaded archive." -ForegroundColor Red
+                return
+            }
+        }
+        elseif ($ext.download_url -match '\.zip$') {
+            $zipFile = Join-Path $tempDir "ext.zip"
+            Write-Host "  Downloading $($ext.download_url)..." -ForegroundColor DarkGray
+            Invoke-WebRequest -Uri $ext.download_url -OutFile $zipFile -UseBasicParsing
+            Expand-Archive -Path $zipFile -DestinationPath $tempDir -Force
+            $extSourcePath = $tempDir
+        }
+        else {
+            # Git clone
+            Write-Host "  Cloning $($ext.repository)..." -ForegroundColor DarkGray
+            git clone --depth 1 $ext.repository $tempDir 2>$null
+            $extSourcePath = $tempDir
+        }
+
+        # Delegate to existing install logic
+        Invoke-ExtInstall @($extSourcePath)
+        Write-Host ""
+        Write-Host "Extension '$extName' installed from catalog." -ForegroundColor Green
+    }
+    finally {
+        # Cleanup temp
+        if (Test-Path $tempDir) {
+            Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Invoke-ExtInfo([string[]]$args_) {
+    if (-not $args_ -or $args_.Count -eq 0) {
+        Write-Host "ERROR: Extension name required." -ForegroundColor Red
+        Write-Host "  Usage: pforge ext info <name>" -ForegroundColor Yellow
+        exit 1
+    }
+
+    $extName = $args_[0]
+    $catalog = Get-ExtCatalog
+    if (-not $catalog) { return }
+
+    $ext = $catalog.extensions.PSObject.Properties[$extName]
+    if (-not $ext) {
+        Write-Host "ERROR: Extension '$extName' not found in catalog." -ForegroundColor Red
+        exit 1
+    }
+    $ext = $ext.Value
+
+    Write-Host ""
+    Write-Host "╔══════════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
+    Write-Host "║  $($ext.name)" -ForegroundColor Cyan
+    Write-Host "╚══════════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "  ID:          $($ext.id)" -ForegroundColor White
+    Write-Host "  Version:     $($ext.version)" -ForegroundColor White
+    Write-Host "  Author:      $($ext.author)" -ForegroundColor White
+    Write-Host "  Category:    $($ext.category)" -ForegroundColor DarkCyan
+    Write-Host "  Effect:      $($ext.effect)" -ForegroundColor White
+    Write-Host "  License:     $($ext.license)" -ForegroundColor White
+    Write-Host "  Verified:    $(if ($ext.verified) { '✅ Yes' } else { 'No' })" -ForegroundColor White
+    if ($ext.speckit_compatible -eq $true) {
+        Write-Host "  Spec Kit:    ✅ Compatible" -ForegroundColor Green
+    }
+    Write-Host ""
+    Write-Host "  $($ext.description)" -ForegroundColor Gray
+    Write-Host ""
+
+    if ($ext.provides) {
+        Write-Host "  Provides:" -ForegroundColor Yellow
+        if ($ext.provides.instructions) { Write-Host "    $($ext.provides.instructions) instruction files" }
+        if ($ext.provides.agents) { Write-Host "    $($ext.provides.agents) agent definitions" }
+        if ($ext.provides.prompts) { Write-Host "    $($ext.provides.prompts) prompt templates" }
+        if ($ext.provides.skills) { Write-Host "    $($ext.provides.skills) skills" }
+    }
+
+    if ($ext.tags) {
+        Write-Host ""
+        Write-Host "  Tags: $($ext.tags -join ', ')" -ForegroundColor DarkGray
+    }
+
+    Write-Host ""
+    Write-Host "  Repository:  $($ext.repository)" -ForegroundColor DarkGray
+    Write-Host ""
+    Write-Host "  Install: pforge ext add $($ext.id)" -ForegroundColor Green
 }
 
 function Invoke-ExtInstall([string[]]$args_) {

--- a/pforge.sh
+++ b/pforge.sh
@@ -532,7 +532,10 @@ cmd_diff() {
 cmd_ext() {
     if [ $# -eq 0 ]; then
         echo "Extension commands:"
-        echo "  ext install <path>  Install extension from path"
+        echo "  ext search [query]  Search the community catalog"
+        echo "  ext add <name>      Download and install from catalog"
+        echo "  ext info <name>     Show extension details"
+        echo "  ext install <path>  Install extension from local path"
         echo "  ext list            List installed extensions"
         echo "  ext remove <name>   Remove an installed extension"
         return 0
@@ -540,15 +543,188 @@ cmd_ext() {
 
     local subcmd="$1"; shift
     case "$subcmd" in
+        search)  cmd_ext_search "$@" ;;
+        add)     cmd_ext_add "$@" ;;
+        info)    cmd_ext_info "$@" ;;
         install) cmd_ext_install "$@" ;;
         list)    cmd_ext_list ;;
         remove)  cmd_ext_remove "$@" ;;
         *)
             echo "ERROR: Unknown ext command: $subcmd" >&2
-            echo "  Available: install, list, remove" >&2
+            echo "  Available: search, add, info, install, list, remove" >&2
             exit 1
             ;;
     esac
+}
+
+# ─── Catalog Helpers ───────────────────────────────────────────────────
+CATALOG_URL="https://raw.githubusercontent.com/srnichols/plan-forge/master/extensions/catalog.json"
+
+get_ext_catalog() {
+    local local_catalog="$REPO_ROOT/extensions/catalog.json"
+    if [ -f "$local_catalog" ]; then
+        cat "$local_catalog"
+        return 0
+    fi
+    curl -sS --max-time 10 "$CATALOG_URL" 2>/dev/null || {
+        echo "ERROR: Could not fetch extension catalog." >&2
+        return 1
+    }
+}
+
+cmd_ext_search() {
+    local query="${*:-}"
+    local catalog
+    catalog="$(get_ext_catalog)" || return 1
+
+    echo ""
+    if [ -n "$query" ]; then
+        echo "Plan Forge Extension Catalog — matching '$query':"
+    else
+        echo "Plan Forge Extension Catalog:"
+    fi
+    echo "───────────────────────────────────────────────────────"
+
+    # Parse with grep/sed (no jq dependency)
+    local found=0
+    local ids
+    ids="$(echo "$catalog" | grep -oP '"id"\s*:\s*"\K[^"]+' || true)"
+
+    for id in $ids; do
+        local name desc category verified
+        # Extract fields for this extension
+        name="$(echo "$catalog" | grep -A1 "\"$id\"" | grep '"name"' | head -1 | sed 's/.*"name":\s*"//' | sed 's/".*//' || echo "$id")"
+        desc="$(echo "$catalog" | grep -A20 "\"id\":\s*\"$id\"" | grep '"description"' | head -1 | sed 's/.*"description":\s*"//' | sed 's/".*//' || true)"
+        category="$(echo "$catalog" | grep -A25 "\"id\":\s*\"$id\"" | grep '"category"' | head -1 | sed 's/.*"category":\s*"//' | sed 's/".*//' || true)"
+
+        # Filter by query if provided
+        if [ -n "$query" ]; then
+            local q_lower
+            q_lower="$(echo "$query" | tr '[:upper:]' '[:lower:]')"
+            local match=false
+            echo "$name $desc $category $id" | tr '[:upper:]' '[:lower:]' | grep -q "$q_lower" && match=true
+            [ "$match" = false ] && continue
+        fi
+
+        echo "  ✅ $id  [$category]"
+        echo "     $desc"
+        found=$((found + 1))
+    done
+
+    if [ "$found" -eq 0 ]; then
+        echo "  No extensions found$([ -n "$query" ] && echo " matching '$query'")."
+    fi
+    echo ""
+    echo "Use 'pforge ext info <name>' for details, 'pforge ext add <name>' to install."
+}
+
+cmd_ext_add() {
+    if [ $# -eq 0 ]; then
+        echo "ERROR: Extension name required." >&2
+        echo "  Usage: pforge ext add <name>" >&2
+        echo "  Browse: pforge ext search" >&2
+        exit 1
+    fi
+
+    local ext_name="$1"
+    local catalog
+    catalog="$(get_ext_catalog)" || return 1
+
+    # Check if extension exists in catalog
+    if ! echo "$catalog" | grep -q "\"id\":\s*\"$ext_name\""; then
+        echo "ERROR: Extension '$ext_name' not found in catalog." >&2
+        echo "  Run 'pforge ext search' to see available extensions." >&2
+        exit 1
+    fi
+
+    # Extract download URL and path_in_repo
+    local download_url path_in_repo
+    download_url="$(echo "$catalog" | grep -A30 "\"id\":\s*\"$ext_name\"" | grep '"download_url"' | head -1 | sed 's/.*"download_url":\s*"//' | sed 's/".*//')"
+    path_in_repo="$(echo "$catalog" | grep -A30 "\"id\":\s*\"$ext_name\"" | grep '"path_in_repo"' | head -1 | sed 's/.*"path_in_repo":\s*"//' | sed 's/".*//')"
+
+    echo ""
+    echo "Installing: $ext_name"
+
+    local temp_dir
+    temp_dir="$(mktemp -d)/planforge-ext-$ext_name"
+    mkdir -p "$temp_dir"
+
+    # Download
+    if [ -n "$download_url" ]; then
+        local zip_file="$temp_dir/repo.zip"
+        echo "  Downloading..."
+        curl -sL "$download_url" -o "$zip_file" || {
+            echo "ERROR: Download failed." >&2
+            rm -rf "$temp_dir"
+            exit 1
+        }
+        unzip -q "$zip_file" -d "$temp_dir" 2>/dev/null
+
+        if [ -n "$path_in_repo" ]; then
+            # Find extracted root (ZIP has repo-branch/ prefix)
+            local repo_dir
+            repo_dir="$(find "$temp_dir" -maxdepth 1 -type d ! -name "$(basename "$temp_dir")" | head -1)"
+            local ext_source="$repo_dir/$path_in_repo"
+            if [ ! -d "$ext_source" ]; then
+                echo "ERROR: Path '$path_in_repo' not found in archive." >&2
+                rm -rf "$temp_dir"
+                exit 1
+            fi
+            cmd_ext_install "$ext_source"
+        else
+            cmd_ext_install "$temp_dir"
+        fi
+    fi
+
+    rm -rf "$temp_dir"
+    echo ""
+    echo "Extension '$ext_name' installed from catalog."
+}
+
+cmd_ext_info() {
+    if [ $# -eq 0 ]; then
+        echo "ERROR: Extension name required." >&2
+        echo "  Usage: pforge ext info <name>" >&2
+        exit 1
+    fi
+
+    local ext_name="$1"
+    local catalog
+    catalog="$(get_ext_catalog)" || return 1
+
+    if ! echo "$catalog" | grep -q "\"id\":\s*\"$ext_name\""; then
+        echo "ERROR: Extension '$ext_name' not found in catalog." >&2
+        exit 1
+    fi
+
+    # Extract fields
+    local block
+    block="$(echo "$catalog" | grep -A40 "\"id\":\s*\"$ext_name\"")"
+    local name desc author version category license repository
+    name="$(echo "$block" | grep '"name"' | head -1 | sed 's/.*"name":\s*"//' | sed 's/".*//')"
+    desc="$(echo "$block" | grep '"description"' | head -1 | sed 's/.*"description":\s*"//' | sed 's/".*//')"
+    author="$(echo "$block" | grep '"author"' | head -1 | sed 's/.*"author":\s*"//' | sed 's/".*//')"
+    version="$(echo "$block" | grep '"version"' | head -1 | sed 's/.*"version":\s*"//' | sed 's/".*//')"
+    category="$(echo "$block" | grep '"category"' | head -1 | sed 's/.*"category":\s*"//' | sed 's/".*//')"
+    license="$(echo "$block" | grep '"license"' | head -1 | sed 's/.*"license":\s*"//' | sed 's/".*//')"
+    repository="$(echo "$block" | grep '"repository"' | head -1 | sed 's/.*"repository":\s*"//' | sed 's/".*//')"
+
+    echo ""
+    echo "╔══════════════════════════════════════════════════════════════╗"
+    echo "║  $name"
+    echo "╚══════════════════════════════════════════════════════════════╝"
+    echo ""
+    echo "  ID:          $ext_name"
+    echo "  Version:     $version"
+    echo "  Author:      $author"
+    echo "  Category:    $category"
+    echo "  License:     $license"
+    echo ""
+    echo "  $desc"
+    echo ""
+    echo "  Repository:  $repository"
+    echo ""
+    echo "  Install: pforge ext add $ext_name"
 }
 
 cmd_ext_install() {

--- a/templates/.github/prompts/project-principles.prompt.md
+++ b/templates/.github/prompts/project-principles.prompt.md
@@ -12,15 +12,27 @@ their project's non-negotiable principles and produce a completed
 
 ## Step 1: Choose Your Path
 
-Start by asking:
+Start by checking for existing sources:
+
+1. Check if `memory/constitution.md` exists (Spec Kit project constitution)
+2. Check if `docs/plans/PROJECT-PRINCIPLES.md` already exists
+
+**If Spec Kit constitution found:**
+
+> "I found a Spec Kit constitution at `memory/constitution.md`. Want me to convert it to Plan Forge's Project Principles format? I'll map each article to a principle entry and flag any gaps."
+
+If yes: Read the constitution, extract principles, map to the template format, then ask the user to review and adjust.
+
+**If no existing sources found**, ask:
 
 > "How would you like to define your project principles?
 >
 > **A) I know my principles** — I'll interview you section by section
 > **B) Show me starter principles** — I'll suggest common principles for your tech stack and you accept, modify, or reject each one
 > **C) Discover from my codebase** — I'll scan your project files and suggest principles based on patterns I find
+> **D) Import from Spec Kit** — Point me to a `constitution.md` file and I'll convert it
 >
-> Pick A, B, or C (or a combination)."
+> Pick A, B, C, D (or a combination)."
 
 ---
 

--- a/templates/copilot-instructions.md.template
+++ b/templates/copilot-instructions.md.template
@@ -62,6 +62,10 @@ pforge check
 # Multi-agent: setup generates native files for Claude, Cursor, Codex
 # setup.ps1 -Agent claude | setup.sh --agent claude
 
+# Browse and install community extensions
+pforge ext search
+pforge ext add <name>
+
 # CI validation (GitHub Action)
 # uses: srnichols/plan-forge-validate@v1
 ```


### PR DESCRIPTION
## Summary

Combined v1.7 + v1.8: **Extension Ecosystem** and **Spec Kit Bridge** in one release. Makes Plan Forge's extension model Spec Kit-compatible and adds seamless import of Spec Kit artifacts.

### Extension Ecosystem
- \pforge ext search [query]\ — browse community catalog (local first, GitHub fallback)
- \pforge ext add <name>\ — download + install in one step (ZIP + path_in_repo extraction)
- \pforge ext info <name>\ — show details before installing
- \xtensions/catalog.json\ — Spec Kit-compatible format with \speckit_compatible\ flag
- \xtensions/PUBLISHING.md\ — contributor guide for catalog PRs
- 3 seeded extensions: saas-multi-tenancy, azure-infrastructure, plan-forge-memory

### Spec Kit Bridge
- **Step 0 auto-detection**: Scans for \specs/*/spec.md\, \plan.md\, \memory/constitution.md\
- **Import paths**: spec → Plan Forge format, plan → execution contract, constitution → PROJECT-PRINCIPLES.md
- **Project Principles Path D**: Convert Spec Kit constitution directly
- **Catalog compatibility**: Same schema model as Spec Kit's \catalog.community.json\

### Docs Updated (8 files)
CLI-GUIDE, EXTENSIONS.md, CUSTOMIZATION, copilot-instructions + template, faq.html, QUICKSTART, CONTRIBUTING

### Commits
1. \eat(extensions)\: catalog + ext search/add/info (PS + bash parity)
2. \eat(bridge)\: Step 0 Spec Kit detection + constitution import + publishing guide
3. \docs\: full audit pass across 8 documentation files