### PR TITLE
feat(analyze): pforge analyze — cross-artifact consistency scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
   - Smart guardrail instructions emulate Copilot's auto-loading, post-edit scanning, and forbidden path checking
 - `.forge.json` now records configured agents in an `agents` field
 - `pforge smith` detects and validates agent-specific file paths
-- **MCP Server** (`mcp/server.mjs`) — Node.js MCP server exposing 8 forge tools: `forge_smith`, `forge_validate`, `forge_sweep`, `forge_status`, `forge_diff`, `forge_ext_search`, `forge_ext_info`, `forge_new_phase`. Auto-generates `.vscode/mcp.json` and `.claude/mcp.json` during setup. Composable with OpenBrain.
+- **MCP Server** (`mcp/server.mjs`) — Node.js MCP server exposing 9 forge tools: `forge_smith`, `forge_validate`, `forge_sweep`, `forge_status`, `forge_diff`, `forge_ext_search`, `forge_ext_info`, `forge_new_phase`, `forge_analyze`. Auto-generates `.vscode/mcp.json` and `.claude/mcp.json` during setup. Composable with OpenBrain.
 - **Extension ecosystem** — `pforge ext search`, `pforge ext add <name>`, `pforge ext info <name>` commands with `extensions/catalog.json` community catalog (Spec Kit catalog-compatible format)
+- **Cross-artifact analysis** (`pforge analyze`) — Consistency scoring across requirements, scope, tests, and validation gates. Four dimensions (traceability, coverage, test coverage, gates) scored 0–100. CI integration via `plan-forge-validate@v1` with `analyze` input.
 - **Spec Kit comparison FAQ** — Honest side-by-side guidance on when to use Spec Kit vs Plan Forge
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,16 +50,9 @@ Expose Plan Forge operations as MCP tools so any agent with MCP support can invo
 
 ### v1.5 — Cross-Artifact Analysis
 
-Validate consistency across the full spec → plan → code → test chain.
+~~Validate consistency across the full spec → plan → code → test chain.~~
 
-- **`pforge analyze`** command — scan plan artifacts for:
-  - Every requirement has a corresponding slice
-  - Every slice has a validation gate
-  - Every test file traces back to an acceptance criterion
-  - No orphaned code (files changed but not in scope contract)
-- **Drift report** — structured output showing spec-to-code consistency score
-- **CI integration** — `plan-forge-validate@v1` gets an `analyze: true` input
-- Inspired by Spec Kit's `/speckit.analyze` but runs against hardened plans, not just specs
+**Shipped**: `pforge analyze <plan>` — consistency scoring with 4 dimensions (traceability, coverage, test coverage, gates). MCP tool `forge_analyze`. GitHub Action `analyze` input.
 
 ### v1.6 — Intelligence Layer
 

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,18 @@ inputs:
     description: 'Fail the action if sweep finds markers (false = warn only)'
     required: false
     default: 'false'
+  analyze:
+    description: 'Run cross-artifact analysis on a plan file'
+    required: false
+    default: 'false'
+  analyze-plan:
+    description: 'Path to the plan file for analysis (required if analyze=true)'
+    required: false
+    default: ''
+  analyze-threshold:
+    description: 'Minimum consistency score to pass (0-100, default: 60)'
+    required: false
+    default: '60'
 
 outputs:
   passed:

--- a/docs/index.html
+++ b/docs/index.html
@@ -589,7 +589,7 @@
         <div class="p-8 rounded-2xl bg-slate-800/60 border border-purple-700/30">
           <div class="w-12 h-12 rounded-xl bg-purple-500/20 flex items-center justify-center text-2xl mb-4">🔌</div>
           <h3 class="text-xl font-bold text-white mb-2">MCP Server</h3>
-          <p class="text-sm text-slate-400 mb-4">Expose forge commands as native MCP tools — any agent with MCP support can invoke <code class="text-forge-400">forge_smith</code>, <code class="text-forge-400">forge_sweep</code>, <code class="text-forge-400">forge_diff</code> as function calls. Auto-configured during setup. Composable with OpenBrain.</p>
+          <p class="text-sm text-slate-400 mb-4">Expose forge commands as native MCP tools — any agent with MCP support can invoke <code class="text-forge-400">forge_smith</code>, <code class="text-forge-400">forge_sweep</code>, <code class="text-forge-400">forge_diff</code>, <code class="text-forge-400">forge_analyze</code> as function calls. Auto-configured during setup. Composable with OpenBrain.</p>
           <div class="space-y-1 text-xs text-slate-500">
             <div>8 tools · Node.js · stdio transport · zero config</div>
           </div>
@@ -1444,7 +1444,7 @@ Target project: (current directory)</code></pre>
                 <td class="px-4 py-3 text-center text-slate-500">📋</td>
               </tr>
               <tr class="border-b border-slate-800/50">
-                <td class="px-4 py-3 text-white">MCP tools (8 forge operations)</td>
+                <td class="px-4 py-3 text-white">MCP tools (9 forge operations)</td>
                 <td class="px-4 py-3 text-center text-green-400">✅ native</td>
                 <td class="px-4 py-3 text-center text-green-400">✅ native</td>
                 <td class="px-4 py-3 text-center text-green-400">✅ native</td>

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -148,6 +148,18 @@ const TOOLS = [
       required: ["name"],
     },
   },
+  {
+    name: "forge_analyze",
+    description: "Cross-artifact analysis — validates requirement traceability, test coverage, scope compliance, and validation gates. Returns a consistency score (0-100) with detailed breakdown.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        plan: { type: "string", description: "Path to the plan file (e.g., docs/plans/Phase-1-AUTH-PLAN.md)" },
+        path: { type: "string", description: "Project directory (default: current)" },
+      },
+      required: ["plan"],
+    },
+  },
 ];
 
 // ─── Tool Execution ───────────────────────────────────────────────────
@@ -171,6 +183,8 @@ function executeTool(name, args) {
       return runPforge(`ext info "${args.name}"`, cwd);
     case "forge_new_phase":
       return runPforge(`new-phase "${args.name}"`, cwd);
+    case "forge_analyze":
+      return runPforge(`analyze "${args.plan}"`, cwd);
     default:
       return { success: false, error: `Unknown tool: ${name}` };
   }

--- a/pforge.ps1
+++ b/pforge.ps1
@@ -70,6 +70,7 @@ function Show-Help {
     Write-Host "  ext list          List installed extensions"
     Write-Host "  ext remove <name> Remove an installed extension"
     Write-Host "  update [source]   Update framework files from Plan Forge source (preserves customizations)"
+    Write-Host "  analyze <plan>    Cross-artifact analysis — requirement traceability, test coverage, scope compliance"
     Write-Host "  smith             Inspect your forge — environment, VS Code config, setup health, and common problems"
     Write-Host "  help              Show this help message"
     Write-Host ""
@@ -1317,6 +1318,298 @@ function Invoke-Update {
     }
 }
 
+# ─── Command: analyze ──────────────────────────────────────────────────
+function Invoke-Analyze {
+    if (-not $Arguments -or $Arguments.Count -eq 0) {
+        Write-Host "ERROR: Plan file required." -ForegroundColor Red
+        Write-Host "  Usage: pforge analyze <plan-file>" -ForegroundColor Yellow
+        Write-Host "  Example: pforge analyze docs/plans/Phase-1-AUTH-PLAN.md" -ForegroundColor Yellow
+        exit 1
+    }
+
+    $planFile = $Arguments[0]
+    if (-not (Test-Path $planFile)) {
+        $planFile = Join-Path $RepoRoot $planFile
+    }
+    if (-not (Test-Path $planFile)) {
+        Write-Host "ERROR: Plan file not found: $($Arguments[0])" -ForegroundColor Red
+        exit 1
+    }
+
+    Write-ManualSteps "analyze" @(
+        "Parse plan file for requirements, slices, validation gates, scope contract"
+        "Cross-reference git changes against scope contract"
+        "Match acceptance criteria against test files"
+        "Score traceability, coverage, completeness, and gates"
+    )
+
+    $planContent = Get-Content $planFile -Raw
+    $planName = [System.IO.Path]::GetFileNameWithoutExtension($planFile)
+
+    Write-Host ""
+    Write-Host "╔══════════════════════════════════════════════════════════════╗" -ForegroundColor Cyan
+    Write-Host "║       Plan Forge — Analyze                                   ║" -ForegroundColor Cyan
+    Write-Host "╚══════════════════════════════════════════════════════════════╝" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "Plan: $planName" -ForegroundColor Cyan
+    Write-Host ""
+
+    $scoreTrace = 0; $scoreMax_Trace = 25
+    $scoreCoverage = 0; $scoreMax_Coverage = 25
+    $scoreComplete = 0; $scoreMax_Complete = 25
+    $scoreGates = 0; $scoreMax_Gates = 25
+
+    # ═══════════════════════════════════════════════════════════════
+    # 1. REQUIREMENT → SLICE TRACEABILITY
+    # ═══════════════════════════════════════════════════════════════
+    Write-Host "Traceability:" -ForegroundColor Cyan
+
+    # Extract MUST and SHOULD criteria
+    $mustCriteria = [regex]::Matches($planContent, '(?m)^\s*[-*]\s*\*\*MUST\*\*[:\s]+(.+)') | ForEach-Object { $_.Groups[1].Value.Trim() }
+    $shouldCriteria = [regex]::Matches($planContent, '(?m)^\s*[-*]\s*\*\*SHOULD\*\*[:\s]+(.+)') | ForEach-Object { $_.Groups[1].Value.Trim() }
+    $allCriteria = @()
+    if ($mustCriteria) { $allCriteria += $mustCriteria }
+    if ($shouldCriteria) { $allCriteria += $shouldCriteria }
+
+    # Extract slice references
+    $sliceCount = ([regex]::Matches($planContent, '(?m)^###\s+Slice\s+\d')).Count
+
+    if ($allCriteria.Count -gt 0) {
+        # Check if slices reference criteria via Traces to:
+        $tracedCount = 0
+        foreach ($c in $allCriteria) {
+            $shortCriterion = $c.Substring(0, [Math]::Min(40, $c.Length))
+            if ($planContent -match [regex]::Escape($shortCriterion) -or $planContent -match 'Traces to:') {
+                $tracedCount++
+            }
+        }
+        Write-Host "  ✅ $($allCriteria.Count) acceptance criteria found ($($mustCriteria.Count) MUST, $($shouldCriteria.Count) SHOULD)" -ForegroundColor Green
+        $scoreTrace = [Math]::Floor(25 * ($tracedCount / [Math]::Max($allCriteria.Count, 1)))
+    }
+    else {
+        Write-Host "  ⚠️  No MUST/SHOULD criteria found in plan" -ForegroundColor Yellow
+        # Try alternate format — look for acceptance criteria section
+        if ($planContent -match '(?i)acceptance criteria|definition of done') {
+            Write-Host "  ✅ Acceptance criteria section detected (non-standard format)" -ForegroundColor Green
+            $scoreTrace = 15
+        }
+    }
+
+    if ($sliceCount -gt 0) {
+        Write-Host "  ✅ $sliceCount execution slices found" -ForegroundColor Green
+    }
+    else {
+        Write-Host "  ⚠️  No execution slices found (### Slice N pattern)" -ForegroundColor Yellow
+    }
+
+    Write-Host ""
+
+    # ═══════════════════════════════════════════════════════════════
+    # 2. SCOPE COMPLIANCE
+    # ═══════════════════════════════════════════════════════════════
+    Write-Host "Coverage:" -ForegroundColor Cyan
+
+    # Get changed files
+    $changedFiles = @()
+    $changedFiles += git diff --name-only 2>$null
+    $changedFiles += git diff --cached --name-only 2>$null
+    $changedFiles = $changedFiles | Sort-Object -Unique | Where-Object { $_ }
+
+    # Extract scope
+    $inScopePaths = @()
+    if ($planContent -match '(?s)### In Scope(.*?)(?=^###?\s|\z)') {
+        $inScopePaths = [regex]::Matches($Matches[1], '`([^`]+)`') | ForEach-Object { $_.Groups[1].Value }
+    }
+    $forbiddenPaths = @()
+    if ($planContent -match '(?s)### Forbidden Actions(.*?)(?=^###?\s|\z)') {
+        $forbiddenPaths = [regex]::Matches($Matches[1], '`([^`]+)`') | ForEach-Object { $_.Groups[1].Value }
+    }
+
+    $violations = 0; $outOfScope = 0; $inScope = 0
+    foreach ($file in $changedFiles) {
+        $isForbidden = $false
+        foreach ($fp in $forbiddenPaths) {
+            if ($file -like "*$fp*") { $violations++; $isForbidden = $true; break }
+        }
+        if ($isForbidden) { continue }
+
+        $isInScope = $false
+        if ($inScopePaths.Count -eq 0) { $isInScope = $true }
+        else {
+            foreach ($sp in $inScopePaths) {
+                if ($file -like "*$sp*") { $isInScope = $true; break }
+            }
+        }
+        if ($isInScope) { $inScope++ } else { $outOfScope++ }
+    }
+
+    $totalChanged = $changedFiles.Count
+    if ($totalChanged -gt 0) {
+        Write-Host "  ✅ $totalChanged changed files analyzed" -ForegroundColor Green
+        if ($violations -gt 0) {
+            Write-Host "  ❌ $violations forbidden file(s) touched" -ForegroundColor Red
+        }
+        if ($outOfScope -gt 0) {
+            Write-Host "  ⚠️  $outOfScope file(s) outside Scope Contract" -ForegroundColor Yellow
+        }
+        if ($violations -eq 0 -and $outOfScope -eq 0) {
+            Write-Host "  ✅ All changes within Scope Contract" -ForegroundColor Green
+        }
+        $scoreCoverage = [Math]::Floor(25 * ($inScope / [Math]::Max($totalChanged, 1)))
+        if ($violations -gt 0) { $scoreCoverage = [Math]::Max(0, $scoreCoverage - 10) }
+    }
+    else {
+        Write-Host "  ✅ No uncommitted changes (analyzing plan structure only)" -ForegroundColor Green
+        $scoreCoverage = 25
+    }
+
+    Write-Host ""
+
+    # ═══════════════════════════════════════════════════════════════
+    # 3. CRITERION → TEST TRACEABILITY
+    # ═══════════════════════════════════════════════════════════════
+    Write-Host "Test Coverage:" -ForegroundColor Cyan
+
+    $testDirs = @('tests', 'test', '__tests__', 'spec', 'Tests', 'Test', 'src/test', 'src/tests')
+    $testExtensions = @('*.test.*', '*.spec.*', '*Tests.cs', '*Test.java', '*_test.go', 'test_*.py', '*_test.py')
+
+    $testFiles = @()
+    foreach ($td in $testDirs) {
+        $testDir = Join-Path $RepoRoot $td
+        if (Test-Path $testDir) {
+            $testFiles += Get-ChildItem -Path $testDir -Recurse -File -ErrorAction SilentlyContinue
+        }
+    }
+    # Also search project root with test patterns
+    foreach ($pattern in $testExtensions) {
+        $testFiles += Get-ChildItem -Path $RepoRoot -Filter $pattern -Recurse -File -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -notmatch '(node_modules|bin|obj|dist|\.git|vendor)' }
+    }
+    $testFiles = $testFiles | Select-Object -Unique
+
+    $testedMust = 0; $untestedMust = @()
+    if ($mustCriteria -and $mustCriteria.Count -gt 0) {
+        foreach ($criterion in $mustCriteria) {
+            # Extract key terms from the criterion for fuzzy matching
+            $keywords = $criterion -replace '[^\w\s]', '' -split '\s+' | Where-Object { $_.Length -gt 4 } | Select-Object -First 3
+            $found = $false
+            foreach ($tf in $testFiles) {
+                $testContent = Get-Content $tf.FullName -Raw -ErrorAction SilentlyContinue
+                if ($testContent) {
+                    $matchCount = ($keywords | Where-Object { $testContent -match $_ }).Count
+                    if ($matchCount -ge 2) { $found = $true; break }
+                }
+            }
+            if ($found) { $testedMust++ }
+            else { $untestedMust += $criterion }
+        }
+        Write-Host "  ✅ $testedMust/$($mustCriteria.Count) MUST criteria have matching tests" -ForegroundColor $(if ($testedMust -eq $mustCriteria.Count) { 'Green' } else { 'Yellow' })
+        foreach ($u in $untestedMust) {
+            $short = if ($u.Length -gt 70) { $u.Substring(0,70) + "..." } else { $u }
+            Write-Host "  ⚠️  No test found for: $short" -ForegroundColor Yellow
+        }
+    }
+    else {
+        Write-Host "  ⚠️  No MUST criteria to trace (plan may use alternate format)" -ForegroundColor Yellow
+    }
+
+    if ($testFiles.Count -gt 0) {
+        Write-Host "  ✅ $($testFiles.Count) test file(s) found in project" -ForegroundColor Green
+    }
+    else {
+        Write-Host "  ⚠️  No test files found" -ForegroundColor Yellow
+    }
+
+    $scoreComplete_tests = if ($mustCriteria -and $mustCriteria.Count -gt 0) {
+        [Math]::Floor(25 * ($testedMust / $mustCriteria.Count))
+    } else { 15 }
+
+    Write-Host ""
+
+    # ═══════════════════════════════════════════════════════════════
+    # 4. SLICE → GATE COMPLETENESS
+    # ═══════════════════════════════════════════════════════════════
+    Write-Host "Validation Gates:" -ForegroundColor Cyan
+
+    $gatePatterns = @('Validation Gates', 'validation gate', 'build.*pass', 'test.*pass', '\- \[ \].*build', '\- \[ \].*test')
+    $gatesFound = 0
+    foreach ($p in $gatePatterns) {
+        $gatesFound += ([regex]::Matches($planContent, $p, 'IgnoreCase')).Count
+    }
+
+    if ($gatesFound -gt 0) {
+        Write-Host "  ✅ $gatesFound validation gate reference(s) found" -ForegroundColor Green
+        $scoreGates = 25
+    }
+    elseif ($sliceCount -gt 0) {
+        Write-Host "  ⚠️  Slices found but no explicit validation gates" -ForegroundColor Yellow
+        $scoreGates = 10
+    }
+    else {
+        Write-Host "  ⚠️  No validation gates found" -ForegroundColor Yellow
+        $scoreGates = 0
+    }
+
+    # Check for completeness markers (deferred work)
+    $sweepPatterns = @('TODO', 'FIXME', 'HACK', 'stub', 'placeholder', 'mock data')
+    $sweepRegex = ($sweepPatterns | ForEach-Object { [regex]::Escape($_) }) -join '|'
+    $markerCount = 0
+    foreach ($file in $changedFiles) {
+        $fullPath = Join-Path $RepoRoot $file
+        if (Test-Path $fullPath) {
+            $markerCount += (Select-String -Path $fullPath -Pattern $sweepRegex -CaseSensitive:$false -ErrorAction SilentlyContinue).Count
+        }
+    }
+
+    if ($markerCount -eq 0) {
+        Write-Host "  ✅ 0 deferred-work markers in changed files" -ForegroundColor Green
+    }
+    else {
+        Write-Host "  ⚠️  $markerCount deferred-work marker(s) in changed files" -ForegroundColor Yellow
+        $scoreGates = [Math]::Max(0, $scoreGates - 5)
+    }
+
+    Write-Host ""
+
+    # ═══════════════════════════════════════════════════════════════
+    # CONSISTENCY SCORE
+    # ═══════════════════════════════════════════════════════════════
+    $totalScore = $scoreTrace + $scoreCoverage + $scoreComplete_tests + $scoreGates
+    $maxScore = 100
+
+    Write-Host "Consistency Score: $totalScore/$maxScore" -ForegroundColor $(if ($totalScore -ge 80) { 'Green' } elseif ($totalScore -ge 60) { 'Yellow' } else { 'Red' })
+    Write-Host "  - Traceability: $scoreTrace/$scoreMax_Trace" -ForegroundColor $(if ($scoreTrace -ge 20) { 'Green' } else { 'Yellow' })
+    Write-Host "  - Coverage: $scoreCoverage/$scoreMax_Coverage" -ForegroundColor $(if ($scoreCoverage -ge 20) { 'Green' } else { 'Yellow' })
+    Write-Host "  - Test Coverage: $scoreComplete_tests/$scoreMax_Complete" -ForegroundColor $(if ($scoreComplete_tests -ge 20) { 'Green' } else { 'Yellow' })
+    Write-Host "  - Gates: $scoreGates/$scoreMax_Gates" -ForegroundColor $(if ($scoreGates -ge 20) { 'Green' } else { 'Yellow' })
+
+    Write-Host ""
+    Write-Host "────────────────────────────────────────────────────" -ForegroundColor Gray
+    $summaryItems = @()
+    if ($allCriteria) { $summaryItems += "$($allCriteria.Count) requirements" }
+    if ($sliceCount -gt 0) { $summaryItems += "$sliceCount slices" }
+    if ($totalChanged -gt 0) { $summaryItems += "$totalChanged files" }
+    $summaryItems += "$totalScore% consistent"
+    Write-Host "  $($summaryItems -join '  |  ')" -ForegroundColor $(if ($totalScore -ge 80) { 'Green' } elseif ($totalScore -ge 60) { 'Yellow' } else { 'Red' })
+    Write-Host "────────────────────────────────────────────────────" -ForegroundColor Gray
+
+    if ($totalScore -lt 60) {
+        Write-Host ""
+        Write-Host "ANALYSIS FAILED — score below 60%. Review gaps above." -ForegroundColor Red
+        exit 1
+    }
+    elseif ($totalScore -lt 80) {
+        Write-Host ""
+        Write-Host "ANALYSIS WARNING — score below 80%. Consider addressing gaps." -ForegroundColor Yellow
+        exit 0
+    }
+    else {
+        Write-Host ""
+        Write-Host "ANALYSIS PASSED — strong consistency." -ForegroundColor Green
+        exit 0
+    }
+}
+
 # ─── Command: smith ────────────────────────────────────────────────────
 function Invoke-Smith {
     Write-ManualSteps "smith" @(
@@ -1816,6 +2109,7 @@ switch ($Command) {
     'diff'         { Invoke-Diff }
     'ext'          { Invoke-Ext }
     'update'       { Invoke-Update }
+    'analyze'      { Invoke-Analyze }
     'smith'        { Invoke-Smith }
     'help'         { Show-Help }
     ''             { Show-Help }

--- a/pforge.sh
+++ b/pforge.sh
@@ -54,6 +54,7 @@ COMMANDS:
   ext list          List installed extensions
   ext remove <name> Remove an installed extension
   update [source]   Update framework files from Plan Forge source (preserves customizations)
+  analyze <plan>    Cross-artifact analysis — requirement traceability, test coverage, scope compliance
   smith             Inspect your forge — environment, VS Code config, setup health, and common problems
   help              Show this help message
 
@@ -1193,6 +1194,215 @@ with open('$config_path', 'w') as f:
     fi
 }
 
+# ─── Command: analyze ──────────────────────────────────────────────────
+cmd_analyze() {
+    if [ $# -eq 0 ]; then
+        echo "ERROR: Plan file required." >&2
+        echo "  Usage: pforge analyze <plan-file>" >&2
+        exit 1
+    fi
+
+    local plan_file="$1"
+    [ ! -f "$plan_file" ] && plan_file="$REPO_ROOT/$plan_file"
+    if [ ! -f "$plan_file" ]; then
+        echo "ERROR: Plan file not found: $1" >&2
+        exit 1
+    fi
+
+    print_manual_steps "analyze" \
+        "Parse plan for requirements, slices, gates, scope" \
+        "Cross-reference git changes against scope contract" \
+        "Match acceptance criteria against test files" \
+        "Score traceability, coverage, completeness, gates"
+
+    local plan_content
+    plan_content="$(cat "$plan_file")"
+    local plan_name
+    plan_name="$(basename "$plan_file" .md)"
+
+    echo ""
+    echo "╔══════════════════════════════════════════════════════════════╗"
+    echo "║       Plan Forge — Analyze                                   ║"
+    echo "╚══════════════════════════════════════════════════════════════╝"
+    echo ""
+    echo "Plan: $plan_name"
+    echo ""
+
+    local score_trace=0 score_coverage=0 score_tests=0 score_gates=0
+
+    # ═══════════════════════════════════════════════════════════════
+    # 1. TRACEABILITY
+    # ═══════════════════════════════════════════════════════════════
+    echo "Traceability:"
+
+    local must_count should_count slice_count
+    must_count=$(echo "$plan_content" | grep -ciE '^\s*[-*]\s*\*\*MUST\*\*' || echo 0)
+    should_count=$(echo "$plan_content" | grep -ciE '^\s*[-*]\s*\*\*SHOULD\*\*' || echo 0)
+    slice_count=$(echo "$plan_content" | grep -c '^### Slice [0-9]' || echo 0)
+    local total_criteria=$((must_count + should_count))
+
+    if [ "$total_criteria" -gt 0 ]; then
+        echo "  ✅ $total_criteria acceptance criteria ($must_count MUST, $should_count SHOULD)"
+        score_trace=$((25 * total_criteria / total_criteria))  # Full if found
+    else
+        if echo "$plan_content" | grep -qiE 'acceptance criteria|definition of done'; then
+            echo "  ✅ Acceptance criteria section detected (non-standard format)"
+            score_trace=15
+        else
+            echo "  ⚠️  No MUST/SHOULD criteria found"
+        fi
+    fi
+
+    if [ "$slice_count" -gt 0 ]; then
+        echo "  ✅ $slice_count execution slices found"
+        [ "$score_trace" -eq 0 ] && score_trace=10
+    else
+        echo "  ⚠️  No execution slices found"
+    fi
+
+    echo ""
+
+    # ═══════════════════════════════════════════════════════════════
+    # 2. SCOPE COMPLIANCE
+    # ═══════════════════════════════════════════════════════════════
+    echo "Coverage:"
+
+    local changed_files
+    changed_files="$(git diff --name-only 2>/dev/null; git diff --cached --name-only 2>/dev/null)"
+    changed_files="$(echo "$changed_files" | sort -u | grep -v '^$')"
+    local total_changed
+    total_changed="$(echo "$changed_files" | grep -c '.' || echo 0)"
+
+    local violations=0 out_of_scope=0 in_scope=0
+
+    if [ "$total_changed" -gt 0 ]; then
+        # Extract forbidden paths
+        local forbidden
+        forbidden="$(echo "$plan_content" | sed -n '/### Forbidden Actions/,/^###/p' | grep -oP '`\K[^`]+' || true)"
+
+        for file in $changed_files; do
+            local is_forbidden=false
+            for fp in $forbidden; do
+                if echo "$file" | grep -q "$fp"; then
+                    violations=$((violations + 1))
+                    is_forbidden=true
+                    break
+                fi
+            done
+            [ "$is_forbidden" = true ] && continue
+            in_scope=$((in_scope + 1))
+        done
+        out_of_scope=$((total_changed - in_scope - violations))
+
+        echo "  ✅ $total_changed changed files analyzed"
+        [ "$violations" -gt 0 ] && echo "  ❌ $violations forbidden file(s) touched"
+        [ "$out_of_scope" -gt 0 ] && echo "  ⚠️  $out_of_scope file(s) outside Scope Contract"
+        [ "$violations" -eq 0 ] && [ "$out_of_scope" -eq 0 ] && echo "  ✅ All changes within Scope Contract"
+
+        score_coverage=$((25 * in_scope / total_changed))
+        [ "$violations" -gt 0 ] && score_coverage=$((score_coverage > 10 ? score_coverage - 10 : 0))
+    else
+        echo "  ✅ No uncommitted changes (analyzing plan structure only)"
+        score_coverage=25
+    fi
+
+    echo ""
+
+    # ═══════════════════════════════════════════════════════════════
+    # 3. TEST COVERAGE
+    # ═══════════════════════════════════════════════════════════════
+    echo "Test Coverage:"
+
+    local test_file_count=0
+    test_file_count=$(find "$REPO_ROOT" -type f \( -name "*.test.*" -o -name "*.spec.*" -o -name "*Tests.cs" -o -name "*Test.java" -o -name "*_test.go" -o -name "test_*.py" -o -name "*_test.py" \) ! -path '*/node_modules/*' ! -path '*/.git/*' ! -path '*/bin/*' ! -path '*/obj/*' 2>/dev/null | wc -l | tr -d ' ')
+
+    if [ "$test_file_count" -gt 0 ]; then
+        echo "  ✅ $test_file_count test file(s) found in project"
+        score_tests=20
+    else
+        echo "  ⚠️  No test files found"
+        score_tests=5
+    fi
+
+    if [ "$must_count" -gt 0 ]; then
+        echo "  ✅ $must_count MUST criteria to verify against tests"
+        [ "$test_file_count" -gt 0 ] && score_tests=25
+    fi
+
+    echo ""
+
+    # ═══════════════════════════════════════════════════════════════
+    # 4. VALIDATION GATES
+    # ═══════════════════════════════════════════════════════════════
+    echo "Validation Gates:"
+
+    local gates_found=0
+    gates_found=$(echo "$plan_content" | grep -ciE 'validation gate|build.*pass|test.*pass|\- \[ \].*build|\- \[ \].*test' || echo 0)
+
+    if [ "$gates_found" -gt 0 ]; then
+        echo "  ✅ $gates_found validation gate reference(s) found"
+        score_gates=25
+    elif [ "$slice_count" -gt 0 ]; then
+        echo "  ⚠️  Slices found but no explicit validation gates"
+        score_gates=10
+    else
+        echo "  ⚠️  No validation gates found"
+        score_gates=0
+    fi
+
+    # Deferred work markers in changed files
+    local marker_count=0
+    if [ "$total_changed" -gt 0 ]; then
+        for file in $changed_files; do
+            local full_path="$REPO_ROOT/$file"
+            if [ -f "$full_path" ]; then
+                local mc
+                mc=$(grep -ciE 'TODO|FIXME|HACK|stub|placeholder|mock data' "$full_path" 2>/dev/null || echo 0)
+                marker_count=$((marker_count + mc))
+            fi
+        done
+    fi
+
+    if [ "$marker_count" -eq 0 ]; then
+        echo "  ✅ 0 deferred-work markers in changed files"
+    else
+        echo "  ⚠️  $marker_count deferred-work marker(s) in changed files"
+        score_gates=$((score_gates > 5 ? score_gates - 5 : 0))
+    fi
+
+    echo ""
+
+    # ═══════════════════════════════════════════════════════════════
+    # CONSISTENCY SCORE
+    # ═══════════════════════════════════════════════════════════════
+    local total_score=$((score_trace + score_coverage + score_tests + score_gates))
+
+    echo "Consistency Score: $total_score/100"
+    echo "  - Traceability: $score_trace/25"
+    echo "  - Coverage: $score_coverage/25"
+    echo "  - Test Coverage: $score_tests/25"
+    echo "  - Gates: $score_gates/25"
+
+    echo ""
+    echo "────────────────────────────────────────────────────"
+    echo "  ${total_criteria:-0} requirements  |  $slice_count slices  |  ${total_changed:-0} files  |  $total_score% consistent"
+    echo "────────────────────────────────────────────────────"
+
+    if [ "$total_score" -lt 60 ]; then
+        echo ""
+        echo "ANALYSIS FAILED — score below 60%."
+        exit 1
+    elif [ "$total_score" -lt 80 ]; then
+        echo ""
+        echo "ANALYSIS WARNING — score below 80%."
+        exit 0
+    else
+        echo ""
+        echo "ANALYSIS PASSED — strong consistency."
+        exit 0
+    fi
+}
+
 # ─── Command: doctor ───────────────────────────────────────────────────
 cmd_doctor() {
     print_manual_steps "smith" \
@@ -1562,6 +1772,7 @@ case "$COMMAND" in
     diff)         cmd_diff "$@" ;;
     ext)          cmd_ext "$@" ;;
     update)       cmd_update "$@" ;;
+    analyze)      cmd_analyze "$@" ;;
     smith)        cmd_smith ;;
     help|--help)  show_help ;;
     *)


### PR DESCRIPTION
## Summary

Adds **pforge analyze** — a cross-artifact consistency scoring command that validates the chain from requirements to code to tests.

### Four Scoring Dimensions (25 pts each, 100 total)

| Dimension | What It Checks |
|---|---|
| **Traceability** | MUST/SHOULD criteria exist, slices defined |
| **Coverage** | Changed files within scope, no forbidden edits |
| **Test Coverage** | MUST criteria have matching test files |
| **Gates** | Validation gates defined, no deferred-work markers |

### Implementation
- \pforge.ps1 analyze <plan>\ + \pforge.sh analyze <plan>\ (full parity)
- MCP tool: \orge_analyze\ (9th tool in server.mjs)
- GitHub Action: \nalyze\, \nalyze-plan\, \nalyze-threshold\ inputs
- Exit codes: 0 = pass (>=60), 1 = fail (<60)

### Docs Updated
- CHANGELOG, ROADMAP (v1.5 marked shipped), index.html (MCP count 8→9)