### PR TITLE
feat(smith): add image generation stack diagnostics

### DIFF
--- a/pforge.ps1
+++ b/pforge.ps1
@@ -1995,6 +1995,54 @@ function Invoke-Smith {
     Write-Host ""
 
     # ═══════════════════════════════════════════════════════════════
+    # 4b-ii. IMAGE GENERATION STACK
+    # ═══════════════════════════════════════════════════════════════
+    if (Test-Path $mcpServer) {
+        Write-Host "Image Generation:" -ForegroundColor Cyan
+
+        # Check for sharp (format conversion)
+        $sharpPath = Join-Path $RepoRoot "pforge-mcp/node_modules/sharp"
+        if (Test-Path $sharpPath) {
+            Doctor-Pass "sharp installed (WebP, PNG, AVIF conversion)"
+        } else {
+            Doctor-Warn "sharp not installed — image format conversion disabled" "Run: cd pforge-mcp && npm install sharp"
+        }
+
+        # Check for API keys (xAI / OpenAI)
+        $hasXai = -not [string]::IsNullOrEmpty($env:XAI_API_KEY)
+        $hasOpenAi = -not [string]::IsNullOrEmpty($env:OPENAI_API_KEY)
+
+        if ($hasXai -and $hasOpenAi) {
+            Doctor-Pass "XAI_API_KEY set (Grok Aurora)"
+            Doctor-Pass "OPENAI_API_KEY set (DALL-E)"
+        } elseif ($hasXai) {
+            Doctor-Pass "XAI_API_KEY set (Grok Aurora)"
+            Doctor-Pass "OPENAI_API_KEY not set (DALL-E unavailable — optional)"
+        } elseif ($hasOpenAi) {
+            Doctor-Pass "OPENAI_API_KEY set (DALL-E)"
+            Doctor-Pass "XAI_API_KEY not set (Grok Aurora unavailable — optional)"
+        } else {
+            Doctor-Warn "No image API keys configured" "Set XAI_API_KEY or OPENAI_API_KEY environment variable for forge_generate_image"
+        }
+
+        # Check Node.js version (sharp requires >= 18.17.0)
+        $nodeCmd = Get-Command node -ErrorAction SilentlyContinue
+        if ($nodeCmd) {
+            $nodeVer = (node --version 2>$null) -replace '^v', ''
+            $nodeMajor = [int]($nodeVer -split '\.')[0]
+            if ($nodeMajor -ge 18) {
+                Doctor-Pass "Node.js v$nodeVer (sharp requires >= 18.17)"
+            } else {
+                Doctor-Fail "Node.js v$nodeVer — sharp requires >= 18.17" "Upgrade Node.js from https://nodejs.org/"
+            }
+        } else {
+            Doctor-Fail "Node.js not found — required for image generation" "Install from https://nodejs.org/"
+        }
+
+        Write-Host ""
+    }
+
+    # ═══════════════════════════════════════════════════════════════
     # 4c. QUORUM MODE
     # ═══════════════════════════════════════════════════════════════
     if (Test-Path $configPath) {

--- a/pforge.sh
+++ b/pforge.sh
@@ -1668,6 +1668,53 @@ cmd_doctor() {
     echo ""
 
     # ═══════════════════════════════════════════════════════════════
+    # 4b-ii. IMAGE GENERATION STACK
+    # ═══════════════════════════════════════════════════════════════
+    if [ -f "$mcp_server" ]; then
+        echo "Image Generation:"
+
+        # Check for sharp (format conversion)
+        if [ -d "$REPO_ROOT/pforge-mcp/node_modules/sharp" ]; then
+            doctor_pass "sharp installed (WebP, PNG, AVIF conversion)"
+        else
+            doctor_warn "sharp not installed — image format conversion disabled" "Run: cd pforge-mcp && npm install sharp"
+        fi
+
+        # Check for API keys
+        local has_xai="${XAI_API_KEY:+1}"
+        local has_openai="${OPENAI_API_KEY:+1}"
+
+        if [ -n "$has_xai" ] && [ -n "$has_openai" ]; then
+            doctor_pass "XAI_API_KEY set (Grok Aurora)"
+            doctor_pass "OPENAI_API_KEY set (DALL-E)"
+        elif [ -n "$has_xai" ]; then
+            doctor_pass "XAI_API_KEY set (Grok Aurora)"
+            doctor_pass "OPENAI_API_KEY not set (DALL-E unavailable — optional)"
+        elif [ -n "$has_openai" ]; then
+            doctor_pass "OPENAI_API_KEY set (DALL-E)"
+            doctor_pass "XAI_API_KEY not set (Grok Aurora unavailable — optional)"
+        else
+            doctor_warn "No image API keys configured" "Set XAI_API_KEY or OPENAI_API_KEY environment variable for forge_generate_image"
+        fi
+
+        # Check Node.js version (sharp requires >= 18.17.0)
+        if command -v node &>/dev/null; then
+            local node_ver
+            node_ver="$(node --version 2>/dev/null | sed 's/^v//')"
+            local node_major="${node_ver%%.*}"
+            if [ "$node_major" -ge 18 ] 2>/dev/null; then
+                doctor_pass "Node.js v$node_ver (sharp requires >= 18.17)"
+            else
+                doctor_fail "Node.js v$node_ver — sharp requires >= 18.17" "Upgrade Node.js from https://nodejs.org/"
+            fi
+        else
+            doctor_fail "Node.js not found — required for image generation" "Install from https://nodejs.org/"
+        fi
+
+        echo ""
+    fi
+
+    # ═══════════════════════════════════════════════════════════════
     # 4c. QUORUM MODE
     # ═══════════════════════════════════════════════════════════════
     local config_path="$REPO_ROOT/.forge.json"


### PR DESCRIPTION
## Changes

Adds a new **Image Generation** section to `pforge smith` that checks:

- **sharp** — installed for WebP/PNG/AVIF format conversion
- **XAI_API_KEY** — set for Grok Aurora image generation
- **OPENAI_API_KEY** — set for DALL-E image generation
- **Node.js version** — >= 18.17 (sharp requirement)

The section only appears when the MCP server is installed (`pforge-mcp/server.mjs` exists).

### Example Output
\\\
Image Generation:
  ✅ sharp installed (WebP, PNG, AVIF conversion)
  ✅ XAI_API_KEY set (Grok Aurora)
  ✅ OPENAI_API_KEY not set (DALL-E unavailable — optional)
  ✅ Node.js v24.11.1 (sharp requires >= 18.17)
\\\

### Files
- `pforge.ps1` — PowerShell implementation
- `pforge.sh` — Bash implementation