### PR TITLE
fix(images): validate output bytes against file extension to prevent MIME mismatches

### DIFF
--- a/pforge-mcp/orchestrator.mjs
+++ b/pforge-mcp/orchestrator.mjs
@@ -630,18 +630,25 @@ export async function generateImage(prompt, options = {}) {
       const { writeFileSync, mkdirSync } = await import("node:fs");
       const { dirname, resolve: pathResolve } = await import("node:path");
 
-      // If conversion succeeded, use the requested path as-is.
-      // If conversion failed (fallback), correct the extension to match actual bytes.
+      // Final safety: re-detect format from the actual output bytes to prevent
+      // MIME mismatches (e.g. xAI Grok Aurora returns JPEG even when PNG requested).
+      // This catches cases where conversion claims success but bytes don't match.
+      const finalDetected = detectImageFormat(finalBuffer);
+
+      // Correct extension if the final bytes don't match the requested format
       let resolvedPath = outputPath;
-      if (!conversion.converted && detected.ext !== targetFormat) {
-        const detectedMeta = FORMAT_META[detected.ext];
-        const targetMeta = FORMAT_META[targetFormat];
-        const alreadyMatch = targetMeta?.aliases?.some((a) => detectedMeta?.aliases?.includes(a));
-        if (!alreadyMatch) {
-          resolvedPath = outputPath.replace(/\.[^.]+$/, `.${finalFormat.ext}`);
-          result.extensionCorrected = true;
-          result.requestedPath = outputPath;
-        }
+      const { extname: getExtForSave } = await import("node:path");
+      const pathExt = getExtForSave(outputPath).toLowerCase().replace(".", "");
+      const pathMeta = FORMAT_META[pathExt];
+      const bytesMeta = FORMAT_META[finalDetected.ext];
+      const extensionMatchesBytes = pathMeta?.aliases?.some((a) => bytesMeta?.aliases?.includes(a));
+
+      if (!extensionMatchesBytes) {
+        resolvedPath = outputPath.replace(/\.[^.]+$/, `.${finalDetected.ext}`);
+        result.extensionCorrected = true;
+        result.requestedPath = outputPath;
+        // Update mimeType to reflect actual saved bytes
+        result.mimeType = finalDetected.mimeType;
       }
 
       const fullPath = pathResolve(cwd, resolvedPath);


### PR DESCRIPTION
## Problem

xAI Grok Aurora always returns JPEG bytes regardless of the requested format. When `sharp` is unavailable (or when the old guard only checked `conversion.converted === false`), images could be saved with the wrong file extension — e.g., JPEG data saved as `.png`.

This causes the Claude API to reject the image with:
```
image was specified using the image/png media type, but the image appears to be a image/jpeg image
```

## Fix

The `generateImage()` function in `orchestrator.mjs` now **always** re-detects the actual image format from the final output bytes using magic byte signatures, regardless of whether sharp conversion succeeded. If the file extension doesn't match the actual bytes, the extension is corrected and `result.mimeType` is updated.

### Before
- Only corrected extension when `conversion.converted === false`
- Trusted the conversion pipeline even when bytes didn't match

### After
- Re-detects format from final buffer bytes every time
- Compares file extension against actual byte signature
- Corrects extension and mimeType if mismatched

## Testing

Discovered via Rummag project — a `test_welcome.png` file was JPEG data (`FF D8 FF` magic bytes) that triggered the Claude API error. After this fix, all generated images get correct extensions matching their actual content.

## Files Changed
- `pforge-mcp/orchestrator.mjs` — 1 file, 18 insertions, 11 deletions