### PR TITLE
feat(crucible): slice 01.1 - persistence + phase naming

### DIFF
--- a/pforge-mcp/crucible-store.mjs
+++ b/pforge-mcp/crucible-store.mjs
@@ -1,0 +1,216 @@
+/**
+ * Plan Forge — Crucible: Smelt Persistence
+ *
+ * A "smelt" is an in-progress conversion of a raw idea into a hardened
+ * phase spec. Each smelt is persisted as `.forge/crucible/<id>.json` and
+ * survives across dashboard refreshes and CLI sessions.
+ *
+ * Record schema:
+ *   {
+ *     id: string,            // UUID
+ *     lane: "tweak" | "feature" | "full",
+ *     rawIdea: string,       // original prompt that started the smelt
+ *     answers: Array<{questionId, answer, answeredAt}>,
+ *     draftMarkdown: string, // rendered via crucible-draft.renderDraft()
+ *     phaseName: string|null,// assigned on finalize
+ *     createdAt: string,     // ISO
+ *     updatedAt: string,     // ISO
+ *     status: "in-progress" | "finalized" | "abandoned",
+ *     source: "human" | "agent",
+ *     parentSmeltId: string|null, // for agent self-referrals
+ *   }
+ *
+ * @module crucible-store
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  writeFileSync,
+  unlinkSync,
+} from "node:fs";
+import { resolve, join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+import { releaseClaim } from "./crucible.mjs";
+
+const VALID_LANES = new Set(["tweak", "feature", "full"]);
+const VALID_SOURCES = new Set(["human", "agent"]);
+const VALID_STATUSES = new Set(["in-progress", "finalized", "abandoned"]);
+
+function crucibleDir(projectDir) {
+  return resolve(projectDir, ".forge", "crucible");
+}
+
+function smeltPath(projectDir, id) {
+  return join(crucibleDir(projectDir), `${id}.json`);
+}
+
+function ensureCrucibleDir(projectDir) {
+  const dir = crucibleDir(projectDir);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+/**
+ * Atomic write via rename-on-write.
+ * @private
+ */
+function atomicWrite(path, content) {
+  const tmp = `${path}.tmp.${process.pid}.${randomUUID().slice(0, 8)}`;
+  writeFileSync(tmp, content, "utf-8");
+  renameSync(tmp, path);
+}
+
+/**
+ * Create a new smelt record.
+ *
+ * @param {object} opts
+ * @param {string} opts.lane - "tweak" | "feature" | "full"
+ * @param {string} opts.rawIdea - original prompt
+ * @param {string} opts.projectDir
+ * @param {string} [opts.source="human"]
+ * @param {string|null} [opts.parentSmeltId=null] - for agent self-referrals
+ * @returns {object} the created smelt record
+ */
+export function createSmelt({ lane, rawIdea, projectDir, source = "human", parentSmeltId = null }) {
+  if (!VALID_LANES.has(lane)) {
+    throw new Error(`createSmelt: invalid lane '${lane}' (must be tweak|feature|full)`);
+  }
+  if (typeof rawIdea !== "string" || !rawIdea.trim()) {
+    throw new Error("createSmelt: rawIdea is required");
+  }
+  if (!VALID_SOURCES.has(source)) {
+    throw new Error(`createSmelt: invalid source '${source}'`);
+  }
+  ensureCrucibleDir(projectDir);
+  const now = new Date().toISOString();
+  const record = {
+    id: randomUUID(),
+    lane,
+    rawIdea: rawIdea.trim(),
+    answers: [],
+    draftMarkdown: "",
+    phaseName: null,
+    createdAt: now,
+    updatedAt: now,
+    status: "in-progress",
+    source,
+    parentSmeltId,
+  };
+  atomicWrite(smeltPath(projectDir, record.id), JSON.stringify(record, null, 2));
+  return record;
+}
+
+/**
+ * Load a smelt by id. Returns null if not found.
+ *
+ * @param {string} id
+ * @param {string} projectDir
+ * @returns {object|null}
+ */
+export function loadSmelt(id, projectDir) {
+  if (!id || typeof id !== "string") return null;
+  const path = smeltPath(projectDir, id);
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, "utf-8");
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Update a smelt with a patch object. Always refreshes `updatedAt`.
+ *
+ * Rejects changes to immutable fields: id, createdAt, source, parentSmeltId.
+ * Validates `lane` and `status` if present in the patch.
+ *
+ * @param {string} id
+ * @param {object} patch
+ * @param {string} projectDir
+ * @returns {object} updated record
+ */
+export function updateSmelt(id, patch, projectDir) {
+  const existing = loadSmelt(id, projectDir);
+  if (!existing) throw new Error(`updateSmelt: smelt '${id}' not found`);
+  if (patch.lane !== undefined && !VALID_LANES.has(patch.lane)) {
+    throw new Error(`updateSmelt: invalid lane '${patch.lane}'`);
+  }
+  if (patch.status !== undefined && !VALID_STATUSES.has(patch.status)) {
+    throw new Error(`updateSmelt: invalid status '${patch.status}'`);
+  }
+  const immutable = ["id", "createdAt", "source", "parentSmeltId"];
+  const next = { ...existing };
+  for (const [k, v] of Object.entries(patch)) {
+    if (immutable.includes(k)) continue;
+    next[k] = v;
+  }
+  next.updatedAt = new Date().toISOString();
+  atomicWrite(smeltPath(projectDir, id), JSON.stringify(next, null, 2));
+  return next;
+}
+
+/**
+ * List all smelts in the project, optionally filtered by status.
+ *
+ * @param {string} projectDir
+ * @param {object} [opts]
+ * @param {string} [opts.status] - filter: "in-progress" | "finalized" | "abandoned"
+ * @returns {object[]} list of smelt records (most recent first)
+ */
+export function listSmelts(projectDir, { status } = {}) {
+  const dir = crucibleDir(projectDir);
+  if (!existsSync(dir)) return [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const smelts = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    if (entry.name === "phase-claims.json" || entry.name === "config.json") continue;
+    if (entry.name === "manual-imports.jsonl") continue;
+    const id = entry.name.slice(0, -".json".length);
+    const rec = loadSmelt(id, projectDir);
+    if (!rec) continue;
+    if (status && rec.status !== status) continue;
+    smelts.push(rec);
+  }
+  smelts.sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1));
+  return smelts;
+}
+
+/**
+ * Abandon a smelt. Marks status and releases any held phase claim.
+ *
+ * @param {string} id
+ * @param {string} projectDir
+ * @returns {{abandoned: boolean}}
+ */
+export function abandonSmelt(id, projectDir) {
+  const existing = loadSmelt(id, projectDir);
+  if (!existing) return { abandoned: false };
+  if (existing.status === "abandoned") return { abandoned: true };
+  if (existing.phaseName) {
+    releaseClaim(projectDir, existing.phaseName, id);
+  }
+  updateSmelt(id, { status: "abandoned" }, projectDir);
+  return { abandoned: true };
+}
+
+/**
+ * Test helper — delete a smelt file outright. Not part of the public API.
+ * @private
+ */
+export function _deleteSmeltForTest(id, projectDir) {
+  const path = smeltPath(projectDir, id);
+  if (existsSync(path)) {
+    try { unlinkSync(path); } catch { /* ignore */ }
+  }
+}

--- a/pforge-mcp/crucible.mjs
+++ b/pforge-mcp/crucible.mjs
@@ -1,0 +1,272 @@
+/**
+ * Plan Forge — Crucible: Phase Naming & Atomic Claims
+ *
+ * Phase naming rules (non-negotiable per Phase-CRUCIBLE-01 design commitment #1):
+ *   - Decimal-only, semver-style: "Phase-01", "Phase-01.1", "Phase-01.1.1"
+ *   - No letters. No mixed styles.
+ *   - A new phase at depth N means "granular refinement of parent N-1"
+ *
+ * Atomic phase-number claim prevents two concurrent smelts from picking the
+ * same number. Uses a rename-on-write pattern on `.forge/crucible/phase-claims.json`.
+ *
+ * @module crucible
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync, unlinkSync } from "node:fs";
+import { resolve, join, dirname } from "node:path";
+import { randomUUID } from "node:crypto";
+
+/**
+ * Regex for valid phase names. Matches:
+ *   Phase-01
+ *   Phase-01.1
+ *   Phase-01.1.1
+ *   Phase-12.34.56
+ *
+ * Rejects:
+ *   Phase-1       (must be zero-padded to at least 2 digits at top level)
+ *   Phase-01D     (no letters)
+ *   Phase-1.C.2   (no letters in decimal parts)
+ *   Phase-CRUCIBLE-01  (the literal string "CRUCIBLE" is a letter block)
+ *
+ * Note: for backward-compat with existing repo plans like Phase-CRUCIBLE-01.md,
+ * validation only runs on NEW smelts. Grandfathered plans keep their names.
+ */
+const PHASE_NAME_RE = /^Phase-(\d{2,})(\.\d+)*$/;
+
+/**
+ * Validate a phase name against the decimal-only semver rule.
+ *
+ * @param {string} name - e.g. "Phase-01" or "Phase-01.1.1"
+ * @returns {boolean}
+ */
+export function isValidPhaseName(name) {
+  if (typeof name !== "string" || !name) return false;
+  return PHASE_NAME_RE.test(name);
+}
+
+/**
+ * Parse a phase name into its numeric segments.
+ *
+ * @param {string} name - e.g. "Phase-01.1.2"
+ * @returns {number[]|null} [01, 1, 2] or null if invalid
+ */
+export function parsePhaseName(name) {
+  if (!isValidPhaseName(name)) return null;
+  const body = name.slice("Phase-".length);
+  return body.split(".").map((s) => parseInt(s, 10));
+}
+
+/**
+ * Compare two phase names for sort order. `01 < 01.1 < 01.2 < 02`.
+ * Returns -1, 0, or +1. Invalid names sort last.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+export function comparePhaseNames(a, b) {
+  const pa = parsePhaseName(a);
+  const pb = parsePhaseName(b);
+  if (!pa && !pb) return 0;
+  if (!pa) return 1;
+  if (!pb) return -1;
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const av = pa[i] ?? -1;
+    const bv = pb[i] ?? -1;
+    if (av !== bv) return av < bv ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * Compute the next available phase number given a list of existing names.
+ *
+ * When `parent` is null: returns the next top-level phase (e.g. existing
+ * ["Phase-01","Phase-02"] → "Phase-03").
+ *
+ * When `parent` is a valid phase name: returns the next child
+ * (e.g. parent="Phase-02", existing ["Phase-02.1","Phase-02.2"] → "Phase-02.3").
+ *
+ * @param {string[]} existingNames - Names already claimed
+ * @param {string|null} [parent=null] - Parent phase for nested naming
+ * @returns {string} Next available phase name
+ */
+export function nextPhaseNumber(existingNames, parent = null) {
+  const valid = existingNames.filter(isValidPhaseName);
+
+  if (parent === null) {
+    // Top-level: find max first segment
+    let max = 0;
+    for (const n of valid) {
+      const segs = parsePhaseName(n);
+      if (segs && segs.length === 1 && segs[0] > max) max = segs[0];
+    }
+    const next = max + 1;
+    return `Phase-${String(next).padStart(2, "0")}`;
+  }
+
+  if (!isValidPhaseName(parent)) {
+    throw new Error(`nextPhaseNumber: invalid parent name '${parent}'`);
+  }
+  const parentSegs = parsePhaseName(parent);
+  const depth = parentSegs.length + 1;
+  let max = 0;
+  for (const n of valid) {
+    const segs = parsePhaseName(n);
+    if (!segs || segs.length !== depth) continue;
+    // Must share parent prefix
+    let prefixMatch = true;
+    for (let i = 0; i < parentSegs.length; i++) {
+      if (segs[i] !== parentSegs[i]) { prefixMatch = false; break; }
+    }
+    if (!prefixMatch) continue;
+    if (segs[depth - 1] > max) max = segs[depth - 1];
+  }
+  return `${parent}.${max + 1}`;
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Atomic phase-number claims
+// ───────────────────────────────────────────────────────────────────────
+
+function crucibleDir(projectDir) {
+  return resolve(projectDir, ".forge", "crucible");
+}
+
+function claimsPath(projectDir) {
+  return join(crucibleDir(projectDir), "phase-claims.json");
+}
+
+function ensureCrucibleDir(projectDir) {
+  const dir = crucibleDir(projectDir);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+/**
+ * Read the current claims table. Missing file → empty object.
+ *
+ * @param {string} projectDir
+ * @returns {{[phaseName: string]: {id: string, claimedAt: string}}}
+ */
+function readClaims(projectDir) {
+  const path = claimsPath(projectDir);
+  if (!existsSync(path)) return {};
+  try {
+    const raw = readFileSync(path, "utf-8");
+    if (!raw.trim()) return {};
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Atomically write the claims table. Uses rename-on-write so concurrent
+ * readers never see a partial file.
+ *
+ * @param {string} projectDir
+ * @param {object} claims
+ */
+function writeClaims(projectDir, claims) {
+  ensureCrucibleDir(projectDir);
+  const path = claimsPath(projectDir);
+  // Unique temp name per call so parallel writers don't collide on the tmp path.
+  const tmp = `${path}.tmp.${process.pid}.${randomUUID().slice(0, 8)}`;
+  writeFileSync(tmp, JSON.stringify(claims, null, 2), "utf-8");
+  renameSync(tmp, path);
+}
+
+/**
+ * Claim a phase number for a smelt. Fails if already claimed.
+ *
+ * Caller is expected to have already checked `nextPhaseNumber()` or chosen
+ * an explicit name. This function is the point of serialization: if two
+ * concurrent callers race on the same name, exactly one succeeds.
+ *
+ * @param {string} projectDir
+ * @param {string} phaseName - must pass `isValidPhaseName`
+ * @param {string} smeltId
+ * @returns {{claimed: true}}
+ * @throws If phaseName is invalid or already claimed
+ */
+export function claimPhaseNumber(projectDir, phaseName, smeltId) {
+  if (!isValidPhaseName(phaseName)) {
+    throw new Error(`claimPhaseNumber: invalid phase name '${phaseName}'`);
+  }
+  if (!smeltId || typeof smeltId !== "string") {
+    throw new Error("claimPhaseNumber: smeltId is required");
+  }
+  // Re-read under the rename boundary. The rename itself is atomic on POSIX
+  // and Windows (same-volume), so read→mutate→write is safe for single-process
+  // scenarios and correct-but-optimistic for multi-process: losers of the race
+  // observe the claim during their read-before-write and raise the "already
+  // claimed" error.
+  const claims = readClaims(projectDir);
+  if (claims[phaseName]) {
+    throw new Error(
+      `claimPhaseNumber: '${phaseName}' already claimed by smelt '${claims[phaseName].id}'`,
+    );
+  }
+  claims[phaseName] = { id: smeltId, claimedAt: new Date().toISOString() };
+  writeClaims(projectDir, claims);
+  // Verify the claim landed (defensive against cross-process races on the rare
+  // case of a concurrent writer overwriting between our read and write).
+  const verify = readClaims(projectDir);
+  if (!verify[phaseName] || verify[phaseName].id !== smeltId) {
+    throw new Error(
+      `claimPhaseNumber: '${phaseName}' was claimed by another smelt during write`,
+    );
+  }
+  return { claimed: true };
+}
+
+/**
+ * Release a phase claim. Safe to call even if the claim doesn't exist.
+ *
+ * @param {string} projectDir
+ * @param {string} phaseName
+ * @param {string} smeltId - must match the claimer to release
+ * @returns {{released: boolean}}
+ */
+export function releaseClaim(projectDir, phaseName, smeltId) {
+  const claims = readClaims(projectDir);
+  if (!claims[phaseName]) return { released: false };
+  if (claims[phaseName].id !== smeltId) {
+    // Not our claim — refuse to release someone else's.
+    return { released: false };
+  }
+  delete claims[phaseName];
+  writeClaims(projectDir, claims);
+  return { released: true };
+}
+
+/**
+ * List all currently claimed phase names.
+ *
+ * @param {string} projectDir
+ * @returns {Array<{phaseName: string, id: string, claimedAt: string}>}
+ */
+export function listClaims(projectDir) {
+  const claims = readClaims(projectDir);
+  return Object.entries(claims).map(([phaseName, v]) => ({
+    phaseName,
+    id: v.id,
+    claimedAt: v.claimedAt,
+  }));
+}
+
+/**
+ * Internal helper exposed for tests — reset the claims file for a project.
+ * Not part of the public API.
+ *
+ * @param {string} projectDir
+ * @private
+ */
+export function _resetClaimsForTest(projectDir) {
+  const path = claimsPath(projectDir);
+  if (existsSync(path)) {
+    try { unlinkSync(path); } catch { /* ignore */ }
+  }
+}

--- a/pforge-mcp/tests/crucible.test.mjs
+++ b/pforge-mcp/tests/crucible.test.mjs
@@ -1,0 +1,365 @@
+/**
+ * Plan Forge — Crucible: phase-naming + persistence unit tests.
+ *
+ * Covers Phase-CRUCIBLE-01 Slice 1 acceptance criteria:
+ *   - MUST: Phase naming validator enforces decimal-only semver rule
+ *   - MUST: Atomic phase-number claim via file lock
+ *   - MUST: Smelts persist to .forge/crucible/<id>.json (resumable)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  isValidPhaseName,
+  parsePhaseName,
+  comparePhaseNames,
+  nextPhaseNumber,
+  claimPhaseNumber,
+  releaseClaim,
+  listClaims,
+  _resetClaimsForTest,
+} from "../crucible.mjs";
+
+import {
+  createSmelt,
+  loadSmelt,
+  updateSmelt,
+  listSmelts,
+  abandonSmelt,
+  _deleteSmeltForTest,
+} from "../crucible-store.mjs";
+
+let projectDir;
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "pforge-crucible-"));
+});
+
+afterEach(() => {
+  try { rmSync(projectDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+// ─── isValidPhaseName / parsePhaseName ───────────────────────────────
+
+describe("isValidPhaseName", () => {
+  it("accepts top-level decimal names", () => {
+    expect(isValidPhaseName("Phase-01")).toBe(true);
+    expect(isValidPhaseName("Phase-12")).toBe(true);
+    expect(isValidPhaseName("Phase-99")).toBe(true);
+  });
+  it("accepts nested decimal names", () => {
+    expect(isValidPhaseName("Phase-01.1")).toBe(true);
+    expect(isValidPhaseName("Phase-01.1.2")).toBe(true);
+    expect(isValidPhaseName("Phase-12.34.56")).toBe(true);
+  });
+  it("rejects letter-bearing names", () => {
+    expect(isValidPhaseName("Phase-01D")).toBe(false);
+    expect(isValidPhaseName("Phase-1.C.2")).toBe(false);
+    expect(isValidPhaseName("Phase-2.1A")).toBe(false);
+    expect(isValidPhaseName("Phase-CRUCIBLE-01")).toBe(false);
+  });
+  it("rejects malformed inputs", () => {
+    expect(isValidPhaseName("phase-01")).toBe(false); // lowercase
+    expect(isValidPhaseName("Phase-1")).toBe(false);  // must be 2+ digits top-level
+    expect(isValidPhaseName("")).toBe(false);
+    expect(isValidPhaseName(null)).toBe(false);
+    expect(isValidPhaseName(undefined)).toBe(false);
+    expect(isValidPhaseName(42)).toBe(false);
+  });
+});
+
+describe("parsePhaseName", () => {
+  it("returns numeric segments", () => {
+    expect(parsePhaseName("Phase-01")).toEqual([1]);
+    expect(parsePhaseName("Phase-12.3.4")).toEqual([12, 3, 4]);
+  });
+  it("returns null for invalid", () => {
+    expect(parsePhaseName("Phase-1D")).toBeNull();
+    expect(parsePhaseName("bad")).toBeNull();
+  });
+});
+
+// ─── comparePhaseNames sort ──────────────────────────────────────────
+
+describe("comparePhaseNames", () => {
+  it("orders 01 < 01.1 < 01.2 < 02", () => {
+    const list = ["Phase-02", "Phase-01.2", "Phase-01", "Phase-01.1"];
+    list.sort(comparePhaseNames);
+    expect(list).toEqual(["Phase-01", "Phase-01.1", "Phase-01.2", "Phase-02"]);
+  });
+  it("orders deeper nesting correctly", () => {
+    const list = ["Phase-01.1.2", "Phase-01.2", "Phase-01.1", "Phase-01.1.1"];
+    list.sort(comparePhaseNames);
+    expect(list).toEqual([
+      "Phase-01.1",
+      "Phase-01.1.1",
+      "Phase-01.1.2",
+      "Phase-01.2",
+    ]);
+  });
+  it("sorts invalid names last, stable for equal", () => {
+    const list = ["Phase-99.9", "garbage", "Phase-01", "also-bad"];
+    list.sort(comparePhaseNames);
+    expect(list[0]).toBe("Phase-01");
+    expect(list[1]).toBe("Phase-99.9");
+  });
+});
+
+// ─── nextPhaseNumber ─────────────────────────────────────────────────
+
+describe("nextPhaseNumber", () => {
+  it("picks next top-level from empty", () => {
+    expect(nextPhaseNumber([])).toBe("Phase-01");
+  });
+  it("picks max+1 top-level", () => {
+    expect(nextPhaseNumber(["Phase-01", "Phase-02", "Phase-05"])).toBe("Phase-06");
+  });
+  it("ignores invalid names when computing max", () => {
+    expect(nextPhaseNumber(["Phase-01", "garbage", "Phase-CRUCIBLE-01"])).toBe("Phase-02");
+  });
+  it("picks next child for a parent", () => {
+    expect(nextPhaseNumber(["Phase-02.1", "Phase-02.2"], "Phase-02")).toBe("Phase-02.3");
+  });
+  it("picks first child when parent has none", () => {
+    expect(nextPhaseNumber(["Phase-02"], "Phase-02")).toBe("Phase-02.1");
+  });
+  it("ignores siblings of other parents", () => {
+    // Phase-03.1 should NOT influence Phase-02's children
+    expect(nextPhaseNumber(["Phase-02.1", "Phase-03.1"], "Phase-02")).toBe("Phase-02.2");
+  });
+  it("rejects invalid parent", () => {
+    expect(() => nextPhaseNumber([], "garbage")).toThrow(/invalid parent/);
+  });
+});
+
+// ─── atomic claimPhaseNumber ─────────────────────────────────────────
+
+describe("claimPhaseNumber", () => {
+  it("claims a fresh phase name", () => {
+    const result = claimPhaseNumber(projectDir, "Phase-01", "smelt-a");
+    expect(result.claimed).toBe(true);
+    const claims = listClaims(projectDir);
+    expect(claims).toHaveLength(1);
+    expect(claims[0].phaseName).toBe("Phase-01");
+    expect(claims[0].id).toBe("smelt-a");
+    expect(claims[0].claimedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+  it("rejects duplicate claim", () => {
+    claimPhaseNumber(projectDir, "Phase-01", "smelt-a");
+    expect(() => claimPhaseNumber(projectDir, "Phase-01", "smelt-b"))
+      .toThrow(/already claimed/);
+  });
+  it("rejects invalid phase name", () => {
+    expect(() => claimPhaseNumber(projectDir, "Phase-CRUCIBLE-01", "smelt-a"))
+      .toThrow(/invalid phase name/);
+  });
+  it("rejects missing smeltId", () => {
+    expect(() => claimPhaseNumber(projectDir, "Phase-01", ""))
+      .toThrow(/smeltId is required/);
+  });
+  it("persists claims across reads", () => {
+    claimPhaseNumber(projectDir, "Phase-01", "smelt-a");
+    claimPhaseNumber(projectDir, "Phase-01.1", "smelt-b");
+    const claims = listClaims(projectDir);
+    expect(claims).toHaveLength(2);
+    const names = claims.map((c) => c.phaseName).sort();
+    expect(names).toEqual(["Phase-01", "Phase-01.1"]);
+  });
+  it("writes to the expected path", () => {
+    claimPhaseNumber(projectDir, "Phase-01", "smelt-a");
+    const path = join(projectDir, ".forge", "crucible", "phase-claims.json");
+    expect(existsSync(path)).toBe(true);
+    const parsed = JSON.parse(readFileSync(path, "utf-8"));
+    expect(parsed["Phase-01"].id).toBe("smelt-a");
+  });
+  it("recovers from corrupt claims file", () => {
+    const dir = join(projectDir, ".forge", "crucible");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "phase-claims.json"), "not json", "utf-8");
+    // Should treat as empty and succeed
+    expect(() => claimPhaseNumber(projectDir, "Phase-01", "smelt-a")).not.toThrow();
+  });
+});
+
+describe("releaseClaim", () => {
+  it("releases a held claim", () => {
+    claimPhaseNumber(projectDir, "Phase-01", "smelt-a");
+    const r = releaseClaim(projectDir, "Phase-01", "smelt-a");
+    expect(r.released).toBe(true);
+    expect(listClaims(projectDir)).toHaveLength(0);
+  });
+  it("refuses to release someone else's claim", () => {
+    claimPhaseNumber(projectDir, "Phase-01", "smelt-a");
+    const r = releaseClaim(projectDir, "Phase-01", "smelt-b");
+    expect(r.released).toBe(false);
+    expect(listClaims(projectDir)).toHaveLength(1);
+  });
+  it("is a no-op for non-existent claim", () => {
+    const r = releaseClaim(projectDir, "Phase-99", "smelt-a");
+    expect(r.released).toBe(false);
+  });
+});
+
+// ─── createSmelt / loadSmelt ─────────────────────────────────────────
+
+describe("createSmelt", () => {
+  it("creates a smelt with defaults", () => {
+    const s = createSmelt({ lane: "feature", rawIdea: "add widget", projectDir });
+    expect(s.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(s.lane).toBe("feature");
+    expect(s.rawIdea).toBe("add widget");
+    expect(s.source).toBe("human");
+    expect(s.status).toBe("in-progress");
+    expect(s.answers).toEqual([]);
+    expect(s.draftMarkdown).toBe("");
+    expect(s.phaseName).toBeNull();
+    expect(s.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(s.updatedAt).toBe(s.createdAt);
+    expect(s.parentSmeltId).toBeNull();
+  });
+  it("supports agent source with parentSmeltId", () => {
+    const parent = createSmelt({ lane: "feature", rawIdea: "x", projectDir });
+    const child = createSmelt({
+      lane: "tweak",
+      rawIdea: "y",
+      projectDir,
+      source: "agent",
+      parentSmeltId: parent.id,
+    });
+    expect(child.source).toBe("agent");
+    expect(child.parentSmeltId).toBe(parent.id);
+  });
+  it("rejects invalid lane", () => {
+    expect(() => createSmelt({ lane: "bogus", rawIdea: "x", projectDir }))
+      .toThrow(/invalid lane/);
+  });
+  it("rejects empty rawIdea", () => {
+    expect(() => createSmelt({ lane: "tweak", rawIdea: "   ", projectDir }))
+      .toThrow(/rawIdea is required/);
+  });
+  it("rejects invalid source", () => {
+    expect(() => createSmelt({ lane: "tweak", rawIdea: "x", projectDir, source: "bot" }))
+      .toThrow(/invalid source/);
+  });
+});
+
+describe("loadSmelt", () => {
+  it("round-trips a created smelt", () => {
+    const s = createSmelt({ lane: "tweak", rawIdea: "fix typo", projectDir });
+    const loaded = loadSmelt(s.id, projectDir);
+    expect(loaded).toEqual(s);
+  });
+  it("returns null for missing id", () => {
+    expect(loadSmelt("nonexistent", projectDir)).toBeNull();
+  });
+  it("returns null for invalid id", () => {
+    expect(loadSmelt("", projectDir)).toBeNull();
+    expect(loadSmelt(null, projectDir)).toBeNull();
+  });
+});
+
+// ─── updateSmelt ─────────────────────────────────────────────────────
+
+describe("updateSmelt", () => {
+  it("merges patch fields and refreshes updatedAt", async () => {
+    const s = createSmelt({ lane: "feature", rawIdea: "x", projectDir });
+    // Wait so updatedAt actually changes
+    await new Promise((r) => setTimeout(r, 10));
+    const updated = updateSmelt(s.id, { draftMarkdown: "# draft" }, projectDir);
+    expect(updated.draftMarkdown).toBe("# draft");
+    expect(updated.updatedAt).not.toBe(s.updatedAt);
+    expect(updated.createdAt).toBe(s.createdAt);
+  });
+  it("ignores attempts to change immutable fields", () => {
+    const s = createSmelt({ lane: "feature", rawIdea: "x", projectDir });
+    const updated = updateSmelt(s.id, {
+      id: "hacked",
+      createdAt: "1999-01-01T00:00:00Z",
+      source: "agent",
+      draftMarkdown: "ok",
+    }, projectDir);
+    expect(updated.id).toBe(s.id);
+    expect(updated.createdAt).toBe(s.createdAt);
+    expect(updated.source).toBe("human");
+    expect(updated.draftMarkdown).toBe("ok");
+  });
+  it("validates lane in patch", () => {
+    const s = createSmelt({ lane: "feature", rawIdea: "x", projectDir });
+    expect(() => updateSmelt(s.id, { lane: "bogus" }, projectDir)).toThrow(/invalid lane/);
+  });
+  it("validates status in patch", () => {
+    const s = createSmelt({ lane: "feature", rawIdea: "x", projectDir });
+    expect(() => updateSmelt(s.id, { status: "bogus" }, projectDir)).toThrow(/invalid status/);
+  });
+  it("throws on missing smelt", () => {
+    expect(() => updateSmelt("nonexistent", { draftMarkdown: "x" }, projectDir))
+      .toThrow(/not found/);
+  });
+});
+
+// ─── listSmelts ──────────────────────────────────────────────────────
+
+describe("listSmelts", () => {
+  it("returns empty for fresh project", () => {
+    expect(listSmelts(projectDir)).toEqual([]);
+  });
+  it("returns smelts newest-first by updatedAt", async () => {
+    const a = createSmelt({ lane: "tweak", rawIdea: "first", projectDir });
+    await new Promise((r) => setTimeout(r, 5));
+    const b = createSmelt({ lane: "tweak", rawIdea: "second", projectDir });
+    const list = listSmelts(projectDir);
+    expect(list).toHaveLength(2);
+    expect(list[0].id).toBe(b.id);
+    expect(list[1].id).toBe(a.id);
+  });
+  it("filters by status", () => {
+    createSmelt({ lane: "tweak", rawIdea: "ongoing", projectDir });
+    const b = createSmelt({ lane: "tweak", rawIdea: "done", projectDir });
+    updateSmelt(b.id, { status: "finalized" }, projectDir);
+    expect(listSmelts(projectDir, { status: "in-progress" })).toHaveLength(1);
+    expect(listSmelts(projectDir, { status: "finalized" })).toHaveLength(1);
+  });
+  it("skips reserved files (phase-claims, config, manual-imports)", () => {
+    createSmelt({ lane: "tweak", rawIdea: "x", projectDir });
+    claimPhaseNumber(projectDir, "Phase-01", "fake-id");
+    const dir = join(projectDir, ".forge", "crucible");
+    writeFileSync(join(dir, "config.json"), "{}", "utf-8");
+    writeFileSync(join(dir, "manual-imports.jsonl"), "", "utf-8");
+    const list = listSmelts(projectDir);
+    expect(list).toHaveLength(1);
+  });
+});
+
+// ─── abandonSmelt ────────────────────────────────────────────────────
+
+describe("abandonSmelt", () => {
+  it("marks status and releases the phase claim", () => {
+    const s = createSmelt({ lane: "feature", rawIdea: "x", projectDir });
+    claimPhaseNumber(projectDir, "Phase-01", s.id);
+    updateSmelt(s.id, { phaseName: "Phase-01" }, projectDir);
+    expect(listClaims(projectDir)).toHaveLength(1);
+    const r = abandonSmelt(s.id, projectDir);
+    expect(r.abandoned).toBe(true);
+    expect(loadSmelt(s.id, projectDir).status).toBe("abandoned");
+    expect(listClaims(projectDir)).toHaveLength(0);
+  });
+  it("is idempotent", () => {
+    const s = createSmelt({ lane: "tweak", rawIdea: "x", projectDir });
+    abandonSmelt(s.id, projectDir);
+    const r = abandonSmelt(s.id, projectDir);
+    expect(r.abandoned).toBe(true);
+  });
+  it("returns false for missing smelt", () => {
+    const r = abandonSmelt("nonexistent", projectDir);
+    expect(r.abandoned).toBe(false);
+  });
+  it("releases claim only for smelts that hold one", () => {
+    const s = createSmelt({ lane: "tweak", rawIdea: "x", projectDir });
+    // No phaseName, no claim
+    abandonSmelt(s.id, projectDir);
+    expect(loadSmelt(s.id, projectDir).status).toBe("abandoned");
+  });
+});


### PR DESCRIPTION
First slice of Phase-CRUCIBLE-01 (v2.37.0 Crucible: structured idea funnel).

## Scope
- `crucible.mjs` — decimal-only phase name validator (`Phase-NN`, `Phase-NN.N`, nested), parser, sort comparator, next-number picker, atomic file-locked phase-number claims (rename-on-write).
- `crucible-store.mjs` — smelt CRUD at `.forge/crucible/<id>.json` with immutable-field enforcement (id/createdAt/source/parentSmeltId), lane/status/source validation, reserved-file skipping, abandon path that releases held phase claims.

## Validation
- 47 new unit tests, all passing
- Full suite: 831/831 green (was 784)
- No TODO/FIXME/HACK markers in new code
- Slice 1 MUST criteria satisfied: phase-naming validator, atomic claim, resumable smelts

## Out of Scope (later slices)
- MCP tools + hub events — Slice 01.2
- UI — Slice 01.3 / 01.4
- Recursion guardrails — Slice 01.5
- Docs + version bump — Slice 01.6

No version bump; feature branch.