### PR TITLE
docs(crucible): sync auto-discovery surfaces for slices 01.1+01.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 **[Website](https://planforge.software/)** · **[Quick Start](https://planforge.software/#quickstart)** · **[Manual](https://planforge.software/manual/)** · **[Documentation](https://planforge.software/docs.html)** · **[FAQ](https://planforge.software/faq.html)** · **[Extensions](https://planforge.software/extensions.html)** · **[Spec Kit Interop](https://planforge.software/speckit-interop.html)**
 
 ```
-34 MCP Tools (+2 Watcher) · 14 LiveGuard · 19 Agents · 12 Skills · 9 Presets · 7 Adapters · 654 Tests
+41 MCP Tools (+2 Watcher) · 14 LiveGuard · 6 Crucible (v2.37-dev) · 19 Agents · 12 Skills · 9 Presets · 7 Adapters · 864 Tests
 ```
 
 ---
@@ -41,7 +41,7 @@ AI coding tools generate code fast — but without structure, that code is untes
 
 > *Vibe coding gets you a prototype. Plan Forge gets you a product — and keeps it healthy.*
 
-**Verified**: 11 phases self-built, 654/654 self-tests, 36 MCP tools, zero manual rollbacks. See [docs/capabilities.md](docs/capabilities.md).
+**Verified**: 12 phases self-built, 864/864 self-tests, 43 MCP tools, zero manual rollbacks. See [docs/capabilities.md](docs/capabilities.md).
 
 ### A/B Test Results (April 2026)
 
@@ -352,7 +352,7 @@ One setup command, every tool: `setup.ps1 -Agent all`
 
 GitHub Copilot (primary) · Claude Code · Cursor · Codex CLI · Gemini CLI · Windsurf · Generic
 
-### MCP Server (36 Tools)
+### MCP Server (43 Tools)
 
 `pforge-mcp/server.mjs` — 20 core tools + 14 LiveGuard tools + 2 Watcher tools (v2.34/v2.35). Live dashboard at `localhost:3100/dashboard`. REST API for external integrations.
 
@@ -379,7 +379,7 @@ Key tools: `forge_run_plan` · `forge_liveguard_run` · `forge_analyze` · `forg
 |----------|---------|
 | **[docs/COPILOT-VSCODE-GUIDE.md](docs/COPILOT-VSCODE-GUIDE.md)** | VS Code + Copilot walkthrough |
 | **[docs/CLI-GUIDE.md](docs/CLI-GUIDE.md)** | `pforge` CLI reference |
-| **[docs/capabilities.md](docs/capabilities.md)** | Full feature reference — all 36 tools, agents, skills |
+| **[docs/capabilities.md](docs/capabilities.md)** | Full feature reference — all 43 tools, agents, skills |
 | **[CUSTOMIZATION.md](CUSTOMIZATION.md)** | Adapt guardrails for your project |
 | **[planforge.software/manual/](https://planforge.software/manual/)** | Interactive web manual (17 chapters + 6 appendices) |
 | **[planforge.software/faq.html](https://planforge.software/faq.html)** | FAQ |

--- a/docs/.well-known/plan-forge.json
+++ b/docs/.well-known/plan-forge.json
@@ -2,7 +2,7 @@
   "name": "Plan Forge",
   "version": "2.35.0",
   "tagline": "Forge the plan. Harden the scope. Ship with confidence.",
-  "description": "AI coding guardrails that convert rough ideas into hardened execution contracts. 7-step pipeline, 36 MCP tools (20 core + 14 LiveGuard + 2 Watcher), self-recursive intelligence, OpenBrain persistent memory, 19 reviewer agents, live dashboard.",
+  "description": "AI coding guardrails that convert rough ideas into hardened execution contracts. 7-step pipeline, 43 MCP tools (21 core + 14 LiveGuard + 2 Watcher + 6 Crucible v2.37-dev), self-recursive intelligence, OpenBrain persistent memory, 19 reviewer agents, live dashboard.",
   "homepage": "https://planforge.software",
   "repository": "https://github.com/srnichols/plan-forge",
   "license": "MIT",
@@ -12,10 +12,11 @@
     "role": "Principal Cloud Solution Architect @ Microsoft"
   },
   "capabilities": {
-    "mcp_tools": 36,
-    "mcp_tools_core": 20,
+    "mcp_tools": 43,
+    "mcp_tools_core": 21,
     "mcp_tools_liveguard": 14,
     "mcp_tools_watcher": 2,
+    "mcp_tools_crucible": 6,
     "agents": 19,
     "skills": 12,
     "instruction_files": "15-18 per preset",
@@ -74,7 +75,16 @@
     "forge_env_diff",
     "forge_fix_proposal",
     "forge_quorum_analyze",
-    "forge_liveguard_run"
+    "forge_liveguard_run",
+    "forge_watch",
+    "forge_watch_live",
+    "forge_memory_report",
+    "forge_crucible_submit",
+    "forge_crucible_ask",
+    "forge_crucible_preview",
+    "forge_crucible_finalize",
+    "forge_crucible_list",
+    "forge_crucible_abandon"
   ],
   "ai_agents_supported": [
     { "name": "copilot", "label": "GitHub Copilot / VS Code", "tier": "primary" },

--- a/docs/capabilities.html
+++ b/docs/capabilities.html
@@ -6,12 +6,12 @@
   <title>Capabilities — Plan Forge | 36 MCP Tools, Quorum Mode, Autonomous Execution, Live Dashboard</title>
   <meta name="description" content="Complete capability reference for Plan Forge — 36 MCP tools (20 core + 14 LiveGuard + 2 Watcher), Quorum Mode (multi-model consensus), DAG-based orchestrator, cost tracking, OTLP telemetry, OpenBrain memory, 19 reviewer agents, 13 skills, REST API for external integration, and a live dashboard." />
   <meta property="og:title" content="Plan Forge Capabilities — Full Tool & Feature Reference" />
-  <meta property="og:description" content="36 MCP tools (20 core + 14 LiveGuard + 2 Watcher), autonomous plan execution, cost tracking, live dashboard, OTLP traces, OpenBrain memory integration, REST API for OpenClaw & external agents. Enterprise-grade AI coding guardrails." />
+  <meta property="og:description" content="43 MCP tools (20 core + 14 LiveGuard + 2 Watcher + 6 Crucible v2.37-dev), autonomous plan execution, cost tracking, live dashboard, OTLP traces, OpenBrain memory integration, REST API for OpenClaw & external agents. Enterprise-grade AI coding guardrails." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://planforge.software/capabilities.html" />
   <meta property="og:image" content="https://planforge.software/assets/og-card.webp" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Plan Forge Capabilities — 36 MCP Tools + Watcher + Autonomous Execution" />
+  <meta name="twitter:title" content="Plan Forge Capabilities — 43 MCP Tools + Watcher + Crucible + Autonomous Execution" />
   <meta name="twitter:description" content="Complete capability reference: orchestrator, dashboard, telemetry, memory, 19 agents, 13 skills." />
   <link rel="canonical" href="https://planforge.software/capabilities.html" />
   <meta name="keywords" content="AI coding guardrails, MCP tools, plan execution, DAG scheduler, cost tracking, OTLP traces, OpenBrain, VS Code Copilot, Claude, GPT, autonomous development, quorum mode, multi-model consensus, A/B testing" />
@@ -82,9 +82,9 @@
     <div class="text-center mb-16">
       <h1 class="text-4xl md:text-5xl font-bold text-white mb-4">Capability Reference</h1>
       <p class="text-xl text-slate-400 max-w-2xl mx-auto">Everything Plan Forge can do — tools, commands, agents, skills, telemetry, and integrations. One page, complete coverage.</p>
-      <img src="assets/capabilities-header.webp" alt="36 MCP tools displayed in a honeycomb grid" class="mx-auto max-w-3xl w-full rounded-2xl border border-slate-700/40 shadow-2xl shadow-amber-500/5 mt-8 mb-4" loading="lazy" />
+      <img src="assets/capabilities-header.webp" alt="43 MCP tools displayed in a honeycomb grid" class="mx-auto max-w-3xl w-full rounded-2xl border border-slate-700/40 shadow-2xl shadow-amber-500/5 mt-8 mb-4" loading="lazy" />
       <div class="mt-6 flex justify-center gap-3 text-sm">
-        <span class="px-3 py-1 rounded-full bg-forge-500/20 text-forge-400 border border-forge-500/30">36 MCP Tools</span>
+        <span class="px-3 py-1 rounded-full bg-forge-500/20 text-forge-400 border border-forge-500/30">43 MCP Tools</span>
         <span class="px-3 py-1 rounded-full bg-blue-500/20 text-blue-400 border border-blue-500/30">19 Agents</span>
         <span class="px-3 py-1 rounded-full bg-green-500/20 text-green-400 border border-green-500/30">13 Skills</span>
         <span class="px-3 py-1 rounded-full bg-purple-500/20 text-purple-400 border border-purple-500/30">15 Dashboard Tabs</span>
@@ -200,6 +200,25 @@
         </div>
         <p class="text-xs text-slate-500 mt-3">14 LiveGuard tools (v2.27–v2.30) plus 2 Watcher tools (v2.34/v2.35). All available as MCP tools and REST endpoints. See <a href="manual/liveguard-tools.html" class="text-amber-400 hover:underline">Chapter 16 — LiveGuard Tools Reference</a> for full documentation.</p>
       </div>
+
+      <!-- Crucible tools preview -->
+      <div class="mt-6 rounded-xl border border-rose-700/30 bg-rose-950/10 p-5">
+        <div class="flex items-center gap-2 mb-3">
+          <span class="text-rose-400">🔥</span>
+          <span class="text-sm font-semibold text-rose-400">Crucible Tools (6 tools — v2.37 in development)</span>
+          <span class="px-2 py-0.5 text-xs rounded-full bg-rose-900/40 text-rose-300 border border-rose-700/30">raw idea → hardened spec funnel</span>
+        </div>
+        <p class="text-xs text-slate-500 mb-3">The pre-forge funnel. Converts rough ideas into scoped plan files through a lane-aware interview (tweak / feature / full), atomic phase-number claims, and Plan Hardener handoff at finalize. Enforces that every plan has a <code class="text-rose-300">crucibleId:</code> frontmatter or was grandfathered via <code class="text-rose-300">--manual-import</code>.</p>
+        <div class="grid gap-2 md:grid-cols-2">
+          <div class="bg-slate-800/40 rounded-lg p-3"><code class="text-rose-400 text-xs">forge_crucible_submit</code><p class="text-xs text-slate-500 mt-1">Start a smelt — infers lane, creates record, emits <code>crucible-smelt-started</code></p></div>
+          <div class="bg-slate-800/40 rounded-lg p-3"><code class="text-rose-400 text-xs">forge_crucible_ask</code><p class="text-xs text-slate-500 mt-1">Next interview question with recommended default sourced from L3 memory / principles / prior phases (or <code>null</code> if none)</p></div>
+          <div class="bg-slate-800/40 rounded-lg p-3"><code class="text-rose-400 text-xs">forge_crucible_preview</code><p class="text-xs text-slate-500 mt-1">Render current draft + list unresolved <code>{{TBD:}}</code> fields</p></div>
+          <div class="bg-slate-800/40 rounded-lg p-3"><code class="text-rose-400 text-xs">forge_crucible_finalize</code><p class="text-xs text-slate-500 mt-1">Atomically claim next phase number, write <code>docs/plans/&lt;phase&gt;.md</code>, hand off to Plan Hardener</p></div>
+          <div class="bg-slate-800/40 rounded-lg p-3"><code class="text-rose-400 text-xs">forge_crucible_list</code><p class="text-xs text-slate-500 mt-1">List smelts by status (in-progress / finalized / abandoned)</p></div>
+          <div class="bg-slate-800/40 rounded-lg p-3"><code class="text-rose-400 text-xs">forge_crucible_abandon</code><p class="text-xs text-slate-500 mt-1">Mark smelt abandoned and release any claimed phase number</p></div>
+        </div>
+        <p class="text-xs text-slate-500 mt-3">Crucible is v2.37 (in development — shipping across 6 slices). Documentation chapter lands in the user manual at v2.37.0 release.</p>
+      </div>
     </section>
 
     <!-- Execution -->
@@ -216,7 +235,7 @@
         </div>
         <div class="bg-slate-800/60 rounded-xl p-6 border border-sky-700/30">
           <h3 class="text-lg font-bold text-white mb-2">Cloud Agent</h3>
-          <p class="text-sm text-slate-400">Copilot cloud agent provisions the environment via <code class="text-sky-300">copilot-setup-steps.yml</code>. Guardrails auto-load, all 36 MCP tools are available, and <code class="text-sky-300">forge_run_plan</code> executes slices autonomously on GitHub Issues.</p>
+          <p class="text-sm text-slate-400">Copilot cloud agent provisions the environment via <code class="text-sky-300">copilot-setup-steps.yml</code>. Guardrails auto-load, all 43 MCP tools are available, and <code class="text-sky-300">forge_run_plan</code> executes slices autonomously on GitHub Issues.</p>
         </div>
         <div class="bg-slate-800/60 rounded-xl p-6 border border-purple-700/30">
           <h3 class="text-lg font-bold text-white mb-2">Parallel</h3>

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,12 +1,12 @@
 # Plan Forge — Capabilities Reference
 
-> **Tools**: 36 MCP (20 core + 14 LiveGuard v2.27–v2.30 + 2 Watcher v2.34/v2.35) | **Presets**: 9 | **Agents**: 19 | **Skills**: 12
+> **Tools**: 43 MCP (20 core + 14 LiveGuard v2.27–v2.30 + 2 Watcher v2.34/v2.35 + 6 Crucible v2.37-dev) | **Presets**: 9 | **Agents**: 19 | **Skills**: 12
 >
 > Machine-readable version: call `forge_capabilities` MCP tool or `GET https://planforge.software/.well-known/plan-forge.json`
 
 ---
 
-## MCP Tools (36)
+## MCP Tools (43)
 
 | Tool | Intent | Cost | Description |
 |------|--------|------|-------------|
@@ -45,6 +45,12 @@
 | `forge_liveguard_run` | liveguard-all | medium | Composite LiveGuard scan: drift + sweep + secrets + regression + deps + alerts + health in one call |
 | `forge_watch` | observe | low | Watcher v2.34/v2.35 — read-only observer that tails another project's pforge run from a second VS Code session. Snapshot or analyze mode. Returns counts, anomalies, recommendations, diff cursor. Optionally appends to watcher's own `.forge/watch-history.jsonl`. |
 | `forge_watch_live` | stream | low | Watcher v2.35 live tail — streams events from a target project for a fixed duration via WebSocket subscription (preferred) or `events.log` polling (fallback). Read-only subscriber. |
+| `forge_crucible_submit` | crucible | low | **v2.37-dev** — Start a smelt (raw idea) in the Crucible interview funnel; infers lane (tweak/feature/full); emits `crucible-smelt-started`. |
+| `forge_crucible_ask` | crucible | low | **v2.37-dev** — Return next interview question (lane-scoped) with optional recommended default sourced from L3 memory / principles / prior phases. |
+| `forge_crucible_preview` | crucible | low | **v2.37-dev** — Render current draft + list unresolved `{{TBD:}}` fields before finalization. |
+| `forge_crucible_finalize` | crucible | medium | **v2.37-dev** — Atomically claim next phase number, write `docs/plans/<phase>.md` with `crucibleId:` frontmatter, mark smelt finalized, emit `crucible-smelt-finalized`. |
+| `forge_crucible_list` | crucible | low | **v2.37-dev** — List all smelts with status filter (in-progress / finalized / abandoned). |
+| `forge_crucible_abandon` | crucible | low | **v2.37-dev** — Mark smelt abandoned, release any claimed phase number. |
 
 ## Execution Modes
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -16,7 +16,7 @@ Plan Forge is an open-source framework that gives AI coding agents (Copilot, Cla
 
 ## Capabilities
 
-- 36 MCP tools (20 core + 14 LiveGuard + 2 Watcher) — start with `forge_capabilities` for full discovery
+- 43 MCP tools (20 core + 14 LiveGuard + 2 Watcher + 6 Crucible v2.37-dev) — start with `forge_capabilities` for full discovery
 - 14 LiveGuard tools — post-coding intelligence: drift scoring, incident tracking, secret scanning, dependency vulnerability monitoring, regression guard, health trend with Health DNA fingerprint, alert triage, environment diff, fix proposals with code snippets, quorum analysis, composite health check (`forge_liveguard_run`)
 - Forge Intelligence — self-recursive improvement: auto-tune escalation chains from model performance, cost estimate calibration from historical actuals, adaptive quorum thresholds, slice auto-split advisories
 - LiveGuard Intelligence — recurring incident detection (auto-escalate systemic), fix proposal outcome tracking, hotspot test priority, Project Health DNA for decay detection

--- a/llms.txt
+++ b/llms.txt
@@ -16,7 +16,7 @@ Plan Forge is an open-source framework that gives AI coding agents (Copilot, Cla
 
 ## Capabilities
 
-- 36 MCP tools (20 core + 14 LiveGuard + 2 Watcher) — start with `forge_capabilities` for full discovery
+- 43 MCP tools (20 core + 14 LiveGuard + 2 Watcher + 6 Crucible v2.37-dev) — start with `forge_capabilities` for full discovery
 - 14 LiveGuard tools — post-coding intelligence: drift scoring, incident tracking, secret scanning, dependency vulnerability monitoring, regression guard, health trend with Health DNA fingerprint, alert triage, environment diff, fix proposals with code snippets, quorum analysis, composite health check (`forge_liveguard_run`)
 - Forge Intelligence — self-recursive improvement: auto-tune escalation chains from model performance, cost estimate calibration from historical actuals, adaptive quorum thresholds, slice auto-split advisories
 - LiveGuard Intelligence — recurring incident detection (auto-escalate systemic), fix proposal outcome tracking, hotspot test priority, Project Health DNA for decay detection


### PR DESCRIPTION
Updates outdated tool counts and mentions the 6 new Crucible MCP tools (flagged v2.37-dev since version bump lands in slice 01.6).

## Changes
- `README.md` — 34+2 tools -> 43, 654 -> 864 tests, 11 -> 12 phases
- `llms.txt` + `docs/llms.txt` — 36 -> 43, Crucible callout
- `docs/capabilities.md` — header + 6 Crucible rows in MCP Tools table
- `docs/capabilities.html` — title, meta, hero chips, Cloud Agent copy, dedicated Crucible tile group (rose theme)
- `docs/.well-known/plan-forge.json` — description, `mcp_tools` count, new `mcp_tools_crucible: 6` key, 9 new entries in `mcp_tools` array (6 Crucible + 2 Watcher + `forge_memory_report` which was also missing)

## Not yet updated (deferred)
- User manual Crucible chapter — slice 01.6
- Dashboard screenshots — slice 01.5 builds the UI; screenshots pointless until then
- `VERSION` + `pforge-mcp/package.json` bump to 2.37.0 — slice 01.6
- `CHANGELOG.md` entry — slice 01.6

## Validation
- `node -e "JSON.parse(fs.readFileSync('docs/.well-known/plan-forge.json'))"` -> OK
- Tool count matches `pforge-mcp/tools.json` (43 unique `forge_*` entries)

Pure docs, no code or test changes.
