### PR TITLE
feat(crucible): slice 01.3 - interview engine + six-block draft renderer

### DIFF
--- a/pforge-mcp/crucible-draft.mjs
+++ b/pforge-mcp/crucible-draft.mjs
@@ -1,0 +1,266 @@
+/**
+ * Plan Forge — Crucible Draft Renderer (Slice 01.3).
+ *
+ * Assembles a phase-doc markdown body from a smelt's raw idea + answers.
+ * Emits the six mandatory blocks every hardened plan must carry:
+ *
+ *   1. Slices              — from scope-files / scope-in answers
+ *   2. Validation Gates    — from validation / validation-gates answer
+ *   3. Stop Conditions     — boilerplate we WILL NOT auto-fill as "answered"
+ *   4. Rollback            — from rollback / rollback-plan answer
+ *   5. Anti-patterns       — from forbidden-actions answer
+ *   6. Change Manifest     — file list derived from scope answers
+ *
+ * Any field that has no answer yet renders as `{{TBD: <question-id>}}`
+ * so `extractUnresolvedFields()` can surface it in the preview.
+ *
+ * Hard rule: this renderer must NEVER inject plausible-sounding filler
+ * in place of a `{{TBD:}}` marker. Slice 01.3 Stop Condition.
+ */
+
+const TBD_REGEX = /\{\{TBD:\s*([a-z0-9-]+)\s*\}\}/gi;
+
+/**
+ * Return a { questionId -> answer } lookup from a smelt.
+ */
+function indexAnswers(smelt) {
+  const out = {};
+  for (const a of (smelt && smelt.answers) || []) {
+    if (a && typeof a.questionId === "string") out[a.questionId] = a.answer;
+  }
+  return out;
+}
+
+function firstAnswer(answers, ...keys) {
+  for (const k of keys) {
+    const v = answers[k];
+    if (typeof v === "string" && v.trim()) return v.trim();
+  }
+  return null;
+}
+
+/**
+ * Expand an answer into a markdown bullet list. Input may be comma- or
+ * newline-separated. If already formatted as a list, return as-is.
+ */
+function asBulletList(value) {
+  if (!value) return null;
+  if (/^\s*[-*]\s+/m.test(value)) return value.trim();
+  const parts = value
+    .split(/\r?\n|,/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (parts.length === 0) return null;
+  return parts.map((p) => `- ${p}`).join("\n");
+}
+
+/**
+ * Render the phase-doc body for a smelt. Caller prepends the crucibleId
+ * frontmatter.
+ *
+ * @param {{
+ *   rawIdea?: string,
+ *   lane?: string,
+ *   source?: string,
+ *   status?: string,
+ *   answers?: Array<{questionId:string, answer:string}>,
+ *   phaseName?: string|null,
+ * }} smelt
+ * @returns {string} markdown body (trailing newline included)
+ */
+export function renderDraft(smelt) {
+  if (!smelt) throw new Error("smelt required");
+  const ans = indexAnswers(smelt);
+  const lane = smelt.lane || "feature";
+  const rawIdea = (smelt.rawIdea || "").trim();
+  const firstLine = rawIdea.split(/\r?\n/)[0].slice(0, 80).trim();
+  const title = firstAnswer(ans, "feature-name") || firstLine || "Untitled smelt";
+
+  const scopeInRaw = firstAnswer(ans, "scope-in", "scope-files", "scope-file", "goal");
+  const scopeIn = asBulletList(scopeInRaw) || `{{TBD: ${lane === "full" ? "scope-in" : "scope-files"}}}`;
+
+  const outOfScope = asBulletList(firstAnswer(ans, "scope-out", "out-of-scope"))
+    || `{{TBD: ${lane === "full" ? "scope-out" : "out-of-scope"}}}`;
+
+  const validationGates =
+    firstAnswer(ans, "validation-gates", "validation")
+    || `{{TBD: ${lane === "tweak" ? "validation" : "validation-gates"}}}`;
+
+  const rollback =
+    firstAnswer(ans, "rollback-plan", "rollback")
+    || `{{TBD: ${lane === "full" ? "rollback-plan" : "rollback"}}}`;
+
+  const forbidden = asBulletList(firstAnswer(ans, "forbidden-actions"))
+    || `{{TBD: forbidden-actions}}`;
+
+  const tests = firstAnswer(ans, "tests") || `{{TBD: tests}}`;
+
+  const changeManifest = asBulletList(firstAnswer(ans, "scope-files", "scope-file", "scope-in"))
+    || `{{TBD: change-manifest}}`;
+
+  const sliceCount = firstAnswer(ans, "slice-count");
+
+  const lines = [];
+  lines.push(`# ${smelt.phaseName ? `${smelt.phaseName}: ` : ""}${title}`);
+  lines.push("");
+  lines.push(`> **Lane**: ${lane}  `);
+  lines.push(`> **Source**: ${smelt.source || "human"}  `);
+  lines.push(`> **Status**: ${smelt.status || "in-progress"}`);
+  lines.push("");
+
+  lines.push("## Raw Idea");
+  lines.push("");
+  lines.push(rawIdea || `{{TBD: ${lane === "full" ? "user-problem" : "goal"}}}`);
+  lines.push("");
+
+  if (lane === "full") {
+    const problem = firstAnswer(ans, "user-problem") || `{{TBD: user-problem}}`;
+    const metric = firstAnswer(ans, "success-metric") || `{{TBD: success-metric}}`;
+    const stack = firstAnswer(ans, "stack-boundary") || `{{TBD: stack-boundary}}`;
+    const dataModel = firstAnswer(ans, "data-model") || `{{TBD: data-model}}`;
+    const apiSurface = firstAnswer(ans, "api-surface") || `{{TBD: api-surface}}`;
+    const security = firstAnswer(ans, "security-posture") || `{{TBD: security-posture}}`;
+
+    lines.push("## Problem & Success Metric");
+    lines.push("");
+    lines.push(`**Problem**: ${problem}`);
+    lines.push("");
+    lines.push(`**Success metric**: ${metric}`);
+    lines.push("");
+
+    lines.push("## Stack Boundary");
+    lines.push("");
+    lines.push(stack);
+    lines.push("");
+
+    lines.push("## Data Model");
+    lines.push("");
+    lines.push(dataModel);
+    lines.push("");
+
+    lines.push("## API Surface");
+    lines.push("");
+    lines.push(apiSurface);
+    lines.push("");
+
+    lines.push("## Security Posture");
+    lines.push("");
+    lines.push(security);
+    lines.push("");
+  }
+
+  // Block 1: Slices
+  lines.push("## Scope Contract");
+  lines.push("");
+  lines.push("**In scope**:");
+  lines.push("");
+  lines.push(scopeIn);
+  lines.push("");
+  lines.push("**Out of scope**:");
+  lines.push("");
+  lines.push(outOfScope);
+  lines.push("");
+
+  lines.push("## Slices");
+  lines.push("");
+  if (sliceCount) {
+    lines.push(`_Estimated: ${sliceCount} slices. Expand each below during Plan Hardener step._`);
+  } else {
+    lines.push("_Slice breakdown is authored during the Plan Hardener step (Session 1, Step 2)._");
+  }
+  lines.push("");
+  lines.push("> Slice template:");
+  lines.push(">");
+  lines.push("> ```");
+  lines.push("> ### Slice N — <name>");
+  lines.push("> Build command: <cmd>");
+  lines.push("> Test command:  <cmd>");
+  lines.push("> Tasks:         <list>");
+  lines.push("> Files:         <manifest>");
+  lines.push("> ```");
+  lines.push("");
+
+  // Block 2: Validation Gates
+  lines.push("## Validation Gates");
+  lines.push("");
+  lines.push(validationGates);
+  lines.push("");
+  lines.push(`**Tests**: ${tests}`);
+  lines.push("");
+
+  // Block 3: Stop Conditions (boilerplate — universal, lane-neutral)
+  lines.push("## Stop Conditions");
+  lines.push("");
+  lines.push("- Validation gate fails and root cause is not identified within 30 minutes");
+  lines.push("- A slice drifts past its declared Scope Contract");
+  lines.push("- A forbidden action (see Anti-patterns) is about to be introduced");
+  lines.push("- Token budget for this phase is exceeded by more than 25%");
+  lines.push("");
+
+  // Block 4: Rollback
+  lines.push("## Rollback");
+  lines.push("");
+  lines.push(rollback);
+  lines.push("");
+
+  // Block 5: Anti-patterns
+  lines.push("## Anti-patterns & Forbidden Actions");
+  lines.push("");
+  lines.push(forbidden);
+  lines.push("");
+
+  // Block 6: Change Manifest
+  lines.push("## Change Manifest");
+  lines.push("");
+  lines.push(changeManifest);
+  lines.push("");
+
+  if (Array.isArray(smelt.answers) && smelt.answers.length > 0) {
+    lines.push("## Interview Log");
+    lines.push("");
+    smelt.answers.forEach((a, i) => {
+      lines.push(`${i + 1}. **${a.questionId}** — ${a.answer}`);
+    });
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Extract the set of unresolved `{{TBD: question-id}}` markers from a
+ * rendered markdown body. Returns an ordered, de-duplicated array of
+ * question ids.
+ *
+ * @param {string} markdown
+ * @returns {string[]}
+ */
+export function extractUnresolvedFields(markdown) {
+  if (typeof markdown !== "string") return [];
+  const seen = new Set();
+  const out = [];
+  let m;
+  TBD_REGEX.lastIndex = 0;
+  while ((m = TBD_REGEX.exec(markdown)) !== null) {
+    const id = m[1].trim();
+    if (!seen.has(id)) {
+      seen.add(id);
+      out.push(id);
+    }
+  }
+  return out;
+}
+
+/**
+ * Six block headings that renderDraft must emit for every lane. Exposed
+ * for tests so the contract is declarative.
+ */
+export const MANDATORY_BLOCKS = Object.freeze([
+  "## Scope Contract",
+  "## Slices",
+  "## Validation Gates",
+  "## Stop Conditions",
+  "## Rollback",
+  "## Anti-patterns & Forbidden Actions",
+  "## Change Manifest",
+]);

--- a/pforge-mcp/crucible-interview.mjs
+++ b/pforge-mcp/crucible-interview.mjs
@@ -1,0 +1,353 @@
+/**
+ * Plan Forge — Crucible Interview Engine (Slice 01.3).
+ *
+ * Lane-scoped question banks plus a strict recommended-default resolver
+ * that refuses to fabricate answers when memory yields nothing.
+ *
+ * Sources consulted (in order) for recommended defaults:
+ *   1. `docs/plans/PROJECT-PRINCIPLES.md` — project-specific commitments
+ *   2. `docs/plans/Phase-*.md`             — conventions from prior phases
+ *   3. `null`                              — explicit "no default" sentinel
+ *
+ * Design Commitment #3 of Phase-CRUCIBLE-01:
+ *   "No defaults = no question (leave blank, don't fabricate)."
+ *
+ * Callers MUST treat `recommendedDefault === null` as "unknown — ask the
+ * human" and MUST NOT substitute boilerplate.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { resolve, join } from "node:path";
+
+// ─── Question banks ──────────────────────────────────────────────────
+// Shape of each question:
+//   { id, prompt, required, defaultSource? }
+// defaultSource is a hint for buildRecommendedDefault — the resolver
+// maps source keys to lookup strategies.
+
+export const TWEAK_QUESTIONS = Object.freeze([
+  Object.freeze({
+    id: "scope-file",
+    prompt: "Which file(s) will this change touch? List paths.",
+    required: true,
+    defaultSource: null,
+  }),
+  Object.freeze({
+    id: "validation",
+    prompt: "How will we verify the fix works? Give the exact build/test command.",
+    required: true,
+    defaultSource: "validation-gate",
+  }),
+  Object.freeze({
+    id: "rollback",
+    prompt: "How do we roll back if this breaks something?",
+    required: true,
+    defaultSource: null,
+  }),
+]);
+
+export const FEATURE_QUESTIONS = Object.freeze([
+  Object.freeze({
+    id: "goal",
+    prompt: "What user-visible outcome does this feature produce?",
+    required: true,
+    defaultSource: null,
+  }),
+  Object.freeze({
+    id: "scope-files",
+    prompt: "Which files/modules are in scope?",
+    required: true,
+    defaultSource: null,
+  }),
+  Object.freeze({
+    id: "out-of-scope",
+    prompt: "What is explicitly out of scope for this phase?",
+    required: true,
+    defaultSource: null,
+  }),
+  Object.freeze({
+    id: "tests",
+    prompt: "What tests prove the feature works? Name the test files or suites.",
+    required: true,
+    defaultSource: "test-framework",
+  }),
+  Object.freeze({
+    id: "validation-gates",
+    prompt: "Which build/test commands gate completion of each slice?",
+    required: true,
+    defaultSource: "validation-gate",
+  }),
+  Object.freeze({
+    id: "rollback",
+    prompt: "How do we roll this feature back cleanly if issues surface post-ship?",
+    required: true,
+    defaultSource: null,
+  }),
+]);
+
+export const FULL_QUESTIONS = Object.freeze([
+  Object.freeze({
+    id: "feature-name",
+    prompt: "Name this phase (short, imperative, no marketing fluff).",
+    required: true,
+    defaultSource: null,
+  }),
+  Object.freeze({
+    id: "user-problem",
+    prompt: "What concrete user or operator problem does this solve?",
+    required: true,
+    defaultSource: null,
+  }),
+  Object.freeze({
+    id: "success-metric",
+    prompt: "How will we measure that the phase succeeded?",
+    required: true,
+    defaultSource: null,
+  }),
+  Object.freeze({
+    id: "stack-boundary",
+    prompt: "What language / framework boundaries apply? (no off-stack work)",
+    required: true,
+    defaultSource: "stack",
+  }),
+  Object.freeze({
+    id: "data-model",
+    prompt: "What new data models, tables, or schema changes are required?",
+    required: true,
+    defaultSource: null,
+  }),
+  Object.freeze({
+    id: "api-surface",
+    prompt: "What new APIs, CLI flags, MCP tools, or events will this expose?",
+    required: true,
+    defaultSource: null,
+  }),
+  Object.freeze({
+    id: "security-posture",
+    prompt: "Security posture — any new secrets, permissions, or attack surface?",
+    required: true,
+    defaultSource: null,
+  }),
+  Object.freeze({
+    id: "scope-in",
+    prompt: "Scope Contract — what IS in scope for this phase? (bullet list)",
+    required: true,
+    defaultSource: null,
+  }),
+  Object.freeze({
+    id: "scope-out",
+    prompt: "Scope Contract — what is OUT of scope? (bullet list)",
+    required: true,
+    defaultSource: null,
+  }),
+  Object.freeze({
+    id: "forbidden-actions",
+    prompt: "Forbidden actions — paths, patterns, or behaviours that MUST NOT be introduced.",
+    required: true,
+    defaultSource: null,
+  }),
+  Object.freeze({
+    id: "slice-count",
+    prompt: "Estimated number of slices (<=6 preferred; split larger phases).",
+    required: true,
+    defaultSource: "slice-count",
+  }),
+  Object.freeze({
+    id: "rollback-plan",
+    prompt: "Rollback plan — exact steps to revert if the phase destabilises main.",
+    required: true,
+    defaultSource: null,
+  }),
+]);
+
+/**
+ * Return the frozen question bank for a given lane.
+ * @param {"tweak"|"feature"|"full"} lane
+ * @returns {ReadonlyArray<{id:string,prompt:string,required:boolean,defaultSource:string|null}>}
+ */
+export function getQuestionBank(lane) {
+  if (lane === "tweak") return TWEAK_QUESTIONS;
+  if (lane === "full") return FULL_QUESTIONS;
+  return FEATURE_QUESTIONS; // default + explicit "feature"
+}
+
+/**
+ * Total number of questions for a lane (used by the hub updated event).
+ * @param {string} lane
+ * @returns {number}
+ */
+export function totalQuestions(lane) {
+  return getQuestionBank(lane).length;
+}
+
+// ─── Next question ───────────────────────────────────────────────────
+
+/**
+ * Return the next unanswered question for a smelt, or null if the
+ * interview is complete.
+ *
+ * Pure on the smelt; reads the filesystem only to resolve recommended
+ * defaults (via buildRecommendedDefault).
+ *
+ * @param {{lane:string, answers:Array<{questionId:string}>}} smelt
+ * @param {{projectDir?: string}} [context]
+ * @returns {{id:string,prompt:string,required:boolean,recommendedDefault:string|null,questionIndex:number,totalQuestions:number}|null}
+ */
+export function getNextQuestion(smelt, context = {}) {
+  if (!smelt || smelt.status && smelt.status !== "in-progress") return null;
+  const bank = getQuestionBank(smelt.lane);
+  const answered = new Set((smelt.answers || []).map((a) => a.questionId));
+  const idx = bank.findIndex((q) => !answered.has(q.id));
+  if (idx === -1) return null;
+  const q = bank[idx];
+  const recommendedDefault = buildRecommendedDefault(q.id, {
+    ...context,
+    defaultSource: q.defaultSource,
+  });
+  return {
+    id: q.id,
+    prompt: q.prompt,
+    required: q.required,
+    recommendedDefault, // null = ask human, do NOT fabricate
+    questionIndex: idx + 1,
+    totalQuestions: bank.length,
+  };
+}
+
+/**
+ * Return a new smelt object with the answer appended. Does not persist.
+ * Caller persists via crucible-store's updateSmelt.
+ *
+ * @param {{answers?:Array}} smelt
+ * @param {string} questionId
+ * @param {string} answer
+ * @returns {object} patched smelt
+ */
+export function recordAnswer(smelt, questionId, answer) {
+  if (!smelt) throw new Error("smelt required");
+  if (typeof questionId !== "string" || !questionId) {
+    throw new Error("questionId required");
+  }
+  if (typeof answer !== "string") {
+    throw new Error("answer must be a string");
+  }
+  const entry = {
+    questionId,
+    answer,
+    recordedAt: new Date().toISOString(),
+  };
+  return { ...smelt, answers: [...(smelt.answers || []), entry] };
+}
+
+// ─── Recommended default resolver ────────────────────────────────────
+
+/**
+ * Strict resolver — returns a string when a source yields a value,
+ * otherwise null. NEVER fabricates.
+ *
+ * @param {string} questionId
+ * @param {{projectDir?:string, defaultSource?:string|null}} context
+ * @returns {string|null}
+ */
+export function buildRecommendedDefault(questionId, context = {}) {
+  const { projectDir, defaultSource } = context;
+  if (!projectDir || !defaultSource) return null;
+
+  // 1) PROJECT-PRINCIPLES.md (primary source)
+  const fromPrinciples = readFromPrinciples(projectDir, defaultSource);
+  if (fromPrinciples) return fromPrinciples;
+
+  // 2) Existing plan conventions (secondary)
+  const fromPlans = readFromPlans(projectDir, defaultSource);
+  if (fromPlans) return fromPlans;
+
+  // 3) Nothing found — explicit null (no fabrication)
+  return null;
+}
+
+function readFromPrinciples(projectDir, defaultSource) {
+  const candidates = [
+    resolve(projectDir, "docs", "plans", "PROJECT-PRINCIPLES.md"),
+    resolve(projectDir, "PROJECT-PRINCIPLES.md"),
+  ];
+  for (const path of candidates) {
+    if (!existsSync(path)) continue;
+    let text;
+    try { text = readFileSync(path, "utf-8"); } catch { continue; }
+    const value = extractPrincipleValue(text, defaultSource);
+    if (value) return value;
+  }
+  return null;
+}
+
+/**
+ * Extract a value matching defaultSource from a PROJECT-PRINCIPLES.md body.
+ * Conservative — only returns a value when the principles file is
+ * unambiguous. Returns null for anything uncertain.
+ */
+function extractPrincipleValue(text, defaultSource) {
+  if (defaultSource === "validation-gate") {
+    // Look for a fenced code block preceded by a "validation" / "build" / "test" heading
+    const m = text.match(/(?:^|\n)#{1,6}\s*(?:validation|build|test)[^\n]*\n+```[\w-]*\n([^\n`]+)\n```/i);
+    if (m && m[1]) return m[1].trim();
+  }
+  if (defaultSource === "test-framework") {
+    const m = text.match(/\btest(?:ing)?\s*(?:framework|runner)\s*[:=]\s*([A-Za-z0-9_+\-./ ]+)/i);
+    if (m && m[1]) return m[1].trim();
+  }
+  if (defaultSource === "stack") {
+    const m = text.match(/(?:^|\n)#{1,6}\s*(?:stack|technology)[^\n]*\n+([^\n#]+)/i);
+    if (m && m[1]) {
+      const v = m[1].trim();
+      if (v.length > 0 && v.length <= 200) return v;
+    }
+  }
+  if (defaultSource === "slice-count") {
+    const m = text.match(/\bmax(?:imum)?\s*slices?\s*[:=]\s*(\d{1,2})\b/i);
+    if (m && m[1]) return m[1];
+  }
+  return null;
+}
+
+function readFromPlans(projectDir, defaultSource) {
+  const plansDir = resolve(projectDir, "docs", "plans");
+  if (!existsSync(plansDir)) return null;
+  let files;
+  try { files = readdirSync(plansDir); } catch { return null; }
+  // Most-recent first by mtime
+  const phaseFiles = files
+    .filter((f) => /^Phase-.+\.md$/.test(f))
+    .map((f) => {
+      const p = join(plansDir, f);
+      let mtime = 0;
+      try { mtime = statSync(p).mtimeMs; } catch { /* ignore */ }
+      return { path: p, mtime };
+    })
+    .sort((a, b) => b.mtime - a.mtime)
+    .slice(0, 5);
+
+  for (const { path } of phaseFiles) {
+    let text;
+    try { text = readFileSync(path, "utf-8"); } catch { continue; }
+    const value = extractPlanValue(text, defaultSource);
+    if (value) return value;
+  }
+  return null;
+}
+
+function extractPlanValue(text, defaultSource) {
+  if (defaultSource === "validation-gate") {
+    // Pick the first **Validation Gate** / **Test command** code block content
+    const m = text.match(/\*\*(?:Validation Gate|Test command|Build command)\*\*[^\n]*\n+```[\w-]*\n([^\n`]+)\n```/i);
+    if (m && m[1]) return m[1].trim();
+    // Fallback: inline backticks after "Test command:"
+    const m2 = text.match(/\*\*Test command\*\*[^`\n]*`([^`\n]+)`/i);
+    if (m2 && m2[1]) return m2[1].trim();
+  }
+  if (defaultSource === "slice-count") {
+    // Count "### Slice N" headers in the recent plan
+    const matches = text.match(/^###\s+Slice\s+\d/gim);
+    if (matches && matches.length > 0) return String(matches.length);
+  }
+  return null;
+}

--- a/pforge-mcp/crucible-server.mjs
+++ b/pforge-mcp/crucible-server.mjs
@@ -4,14 +4,13 @@
  * Pure module used by server.mjs to dispatch the six crucible tools.
  * Keeps server.mjs slim and makes handlers unit-testable without MCP plumbing.
  *
- * Slice 01.2 scope:
- *   - inferLane: keyword heuristic for recommended lane
- *   - submit / ask / preview / finalize / list / abandon handlers
- *   - Emits three hub events: crucible-smelt-started/updated/finalized
- *
- * The interview engine and full draft template land in Slice 01.3.
- * Until then, ask() is a no-op shell and preview/finalize render a stub
- * document from the raw idea + any answers supplied.
+ * Slice 01.2 added: lane inference, submit/ask/preview/finalize/list/abandon,
+ *                   three hub events (crucible-smelt-started/updated/finalized).
+ * Slice 01.3 added: real interview engine (crucible-interview.mjs) and
+ *                   six-block draft renderer (crucible-draft.mjs). The
+ *                   Slice-2 stubs `getNextQuestion`/`renderDraftStub` are
+ *                   replaced with real implementations re-exported here
+ *                   for backwards-compatible imports in tests.
  */
 
 import { mkdirSync, readdirSync, writeFileSync } from "node:fs";
@@ -30,6 +29,14 @@ import {
   loadSmelt,
   updateSmelt,
 } from "./crucible-store.mjs";
+import {
+  getNextQuestion as interviewGetNextQuestion,
+  totalQuestions as interviewTotalQuestions,
+} from "./crucible-interview.mjs";
+import {
+  renderDraft,
+  extractUnresolvedFields,
+} from "./crucible-draft.mjs";
 
 // ─── Lane inference ──────────────────────────────────────────────────
 
@@ -55,44 +62,30 @@ export function inferLane(rawIdea) {
   return "feature";
 }
 
-// ─── Interview stub (Slice 3 replaces) ───────────────────────────────
+// ─── Interview (Slice 01.3 — real engine) ────────────────────────────
 
 /**
- * Placeholder for the Slice 3 interview engine. Returns null to signal
- * "no more questions" so Slice 2 end-to-end flows terminate cleanly.
- * @returns {null}
+ * Return the next unanswered question for a smelt, or null if done.
+ * Thin wrapper so existing callers keep importing from crucible-server.
+ * @param {object} smelt
+ * @param {{projectDir?: string}} [context]
  */
-export function getNextQuestion(_smelt) {
-  return null;
+export function getNextQuestion(smelt, context = {}) {
+  return interviewGetNextQuestion(smelt, context);
 }
 
 /**
- * Render a minimal draft for preview/finalize until Slice 3 ships the
- * proper template. Kept intentionally small so it is unambiguous what
- * Slice 3 will replace.
+ * Slice-01.2 compatibility alias — was the stub draft renderer, now
+ * just delegates to renderDraft. Kept for legacy imports until callers
+ * are migrated.
+ * @deprecated use renderDraft from crucible-draft.mjs
  */
 export function renderDraftStub(smelt) {
-  const firstLine = (smelt.rawIdea || "").split("\n")[0].slice(0, 80).trim();
-  const title = firstLine || "Untitled smelt";
-  const lines = [
-    `# ${smelt.phaseName ? `${smelt.phaseName}: ` : ""}${title}`,
-    "",
-    `> **Lane**: ${smelt.lane}`,
-    `> **Source**: ${smelt.source}`,
-    `> **Status**: ${smelt.status}`,
-    "",
-    "## Raw Idea",
-    "",
-    smelt.rawIdea || "",
-  ];
-  if (Array.isArray(smelt.answers) && smelt.answers.length > 0) {
-    lines.push("", "## Interview Answers", "");
-    smelt.answers.forEach((a, i) => {
-      lines.push(`${i + 1}. **${a.questionId}**: ${a.answer}`);
-    });
-  }
-  return lines.join("\n") + "\n";
+  return renderDraft(smelt);
 }
+
+// Re-export the real renderer for convenience.
+export { renderDraft, extractUnresolvedFields };
 
 // ─── Hub event helper ────────────────────────────────────────────────
 
@@ -151,16 +144,23 @@ export function handleSubmit({ rawIdea, lane, source, parentSmeltId, projectDir,
     id: smelt.id,
     lane: smelt.lane,
     source: smelt.source,
+    totalQuestions: interviewTotalQuestions(smelt.lane),
   });
   return {
     id: smelt.id,
     recommendedLane,
-    firstQuestion: getNextQuestion(smelt),
+    firstQuestion: interviewGetNextQuestion(smelt, { projectDir }),
   };
 }
 
 /**
  * forge_crucible_ask
+ *
+ * The caller sends the answer to whatever question was last returned by
+ * getNextQuestion. We look up that "pending" question on the server so
+ * the questionId recorded in the smelt matches the bank id exactly —
+ * not a client-supplied string — and so the interview cannot record
+ * answers for nonexistent questions.
  */
 export function handleAsk({ id, answer, projectDir, hub }) {
   const smelt = loadSmelt(id, projectDir);
@@ -170,27 +170,29 @@ export function handleAsk({ id, answer, projectDir, hub }) {
   }
 
   let current = smelt;
-  if (answer !== undefined && answer !== null && `${answer}`.length > 0) {
-    const questionId = String(smelt.answers.length + 1);
+  const pending = interviewGetNextQuestion(smelt, { projectDir });
+
+  if (answer !== undefined && answer !== null && `${answer}`.length > 0 && pending) {
     const patch = {
       answers: [
         ...smelt.answers,
-        { questionId, answer: String(answer), recordedAt: new Date().toISOString() },
+        { questionId: pending.id, answer: String(answer), recordedAt: new Date().toISOString() },
       ],
     };
     current = updateSmelt(id, patch, projectDir);
     emit(hub, "crucible-smelt-updated", {
       id: current.id,
       questionIndex: current.answers.length,
-      totalQuestions: null, // Slice 3 supplies total
+      totalQuestions: interviewTotalQuestions(current.lane),
     });
   }
 
-  const nextQuestion = getNextQuestion(current);
+  const nextQuestion = interviewGetNextQuestion(current, { projectDir });
+  const markdown = renderDraft(current);
   return {
     done: nextQuestion === null,
     nextQuestion,
-    draftPreview: renderDraftStub(current),
+    draftPreview: markdown,
   };
 }
 
@@ -200,10 +202,11 @@ export function handleAsk({ id, answer, projectDir, hub }) {
 export function handlePreview({ id, projectDir }) {
   const smelt = loadSmelt(id, projectDir);
   if (!smelt) throw new Error(`smelt not found: ${id}`);
+  const markdown = renderDraft(smelt);
   return {
-    markdown: renderDraftStub(smelt),
+    markdown,
     phaseName: smelt.phaseName,
-    unresolvedFields: [], // Slice 3 fills in from {{TBD:...}} placeholders
+    unresolvedFields: extractUnresolvedFields(markdown),
   };
 }
 
@@ -232,7 +235,7 @@ export function handleFinalize({ id, projectDir, hub }) {
     `source: ${smelt.source}\n` +
     `---\n\n`;
   const bodySmelt = { ...smelt, phaseName };
-  const body = renderDraftStub(bodySmelt);
+  const body = renderDraft(bodySmelt);
   const markdown = frontmatter + body;
   writeFileSync(planPath, markdown, "utf-8");
 

--- a/pforge-mcp/tests/crucible-interview.test.mjs
+++ b/pforge-mcp/tests/crucible-interview.test.mjs
@@ -1,0 +1,399 @@
+/**
+ * Plan Forge — Crucible Interview Engine tests (Slice 01.3).
+ *
+ * Exercises:
+ *   - Question-bank shape per lane
+ *   - getNextQuestion advances, stops, validates
+ *   - recordAnswer immutability
+ *   - buildRecommendedDefault's three-source fallback
+ *   - Strict "no fabrication" rule (returns null when nothing matches)
+ *   - renderDraft emits the 6 mandatory blocks per lane
+ *   - extractUnresolvedFields surfaces {{TBD:}} ids correctly
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import {
+  TWEAK_QUESTIONS,
+  FEATURE_QUESTIONS,
+  FULL_QUESTIONS,
+  getQuestionBank,
+  getNextQuestion,
+  recordAnswer,
+  buildRecommendedDefault,
+  totalQuestions,
+} from "../crucible-interview.mjs";
+
+import {
+  renderDraft,
+  extractUnresolvedFields,
+  MANDATORY_BLOCKS,
+} from "../crucible-draft.mjs";
+
+let projectDir;
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "pforge-crucible-iv-"));
+});
+
+afterEach(() => {
+  try { rmSync(projectDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+// ─── Question banks ──────────────────────────────────────────────────
+
+describe("question banks", () => {
+  it("tweak bank has 3 questions", () => {
+    expect(TWEAK_QUESTIONS).toHaveLength(3);
+  });
+  it("feature bank has 6 questions", () => {
+    expect(FEATURE_QUESTIONS).toHaveLength(6);
+  });
+  it("full bank has 12 questions (mirrors Step-0 prompt)", () => {
+    expect(FULL_QUESTIONS).toHaveLength(12);
+  });
+  it("every question has id, prompt, required fields", () => {
+    const all = [...TWEAK_QUESTIONS, ...FEATURE_QUESTIONS, ...FULL_QUESTIONS];
+    for (const q of all) {
+      expect(typeof q.id).toBe("string");
+      expect(q.id).toMatch(/^[a-z][a-z0-9-]+$/);
+      expect(typeof q.prompt).toBe("string");
+      expect(q.prompt.length).toBeGreaterThan(10);
+      expect(typeof q.required).toBe("boolean");
+    }
+  });
+  it("question ids are unique within each bank", () => {
+    for (const bank of [TWEAK_QUESTIONS, FEATURE_QUESTIONS, FULL_QUESTIONS]) {
+      const ids = bank.map((q) => q.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    }
+  });
+  it("getQuestionBank maps lanes to the right banks", () => {
+    expect(getQuestionBank("tweak")).toBe(TWEAK_QUESTIONS);
+    expect(getQuestionBank("feature")).toBe(FEATURE_QUESTIONS);
+    expect(getQuestionBank("full")).toBe(FULL_QUESTIONS);
+  });
+  it("getQuestionBank defaults to feature for unknown lanes", () => {
+    expect(getQuestionBank("nonsense")).toBe(FEATURE_QUESTIONS);
+  });
+  it("totalQuestions matches bank length", () => {
+    expect(totalQuestions("tweak")).toBe(3);
+    expect(totalQuestions("feature")).toBe(6);
+    expect(totalQuestions("full")).toBe(12);
+  });
+});
+
+// ─── getNextQuestion ─────────────────────────────────────────────────
+
+describe("getNextQuestion", () => {
+  it("returns the first question for a fresh smelt", () => {
+    const q = getNextQuestion({ lane: "feature", answers: [] });
+    expect(q).not.toBeNull();
+    expect(q.id).toBe(FEATURE_QUESTIONS[0].id);
+    expect(q.questionIndex).toBe(1);
+    expect(q.totalQuestions).toBe(6);
+  });
+  it("advances to the next unanswered question", () => {
+    const q = getNextQuestion({
+      lane: "tweak",
+      answers: [{ questionId: "scope-file", answer: "x" }],
+    });
+    expect(q.id).toBe("validation");
+    expect(q.questionIndex).toBe(2);
+  });
+  it("returns null when all questions are answered", () => {
+    const smelt = {
+      lane: "tweak",
+      answers: TWEAK_QUESTIONS.map((q) => ({ questionId: q.id, answer: "x" })),
+    };
+    expect(getNextQuestion(smelt)).toBeNull();
+  });
+  it("returns null for finalized smelts", () => {
+    expect(getNextQuestion({ lane: "feature", answers: [], status: "finalized" })).toBeNull();
+  });
+  it("returns null for abandoned smelts", () => {
+    expect(getNextQuestion({ lane: "feature", answers: [], status: "abandoned" })).toBeNull();
+  });
+  it("includes recommendedDefault field (null when no source)", () => {
+    const q = getNextQuestion({ lane: "feature", answers: [] }, { projectDir });
+    expect(q).toHaveProperty("recommendedDefault");
+    // No PROJECT-PRINCIPLES and no prior plans -> null
+    expect(q.recommendedDefault).toBeNull();
+  });
+  it("returns null for a nullish smelt", () => {
+    expect(getNextQuestion(null)).toBeNull();
+  });
+});
+
+// ─── recordAnswer ────────────────────────────────────────────────────
+
+describe("recordAnswer", () => {
+  it("appends an answer immutably", () => {
+    const smelt = { lane: "tweak", answers: [] };
+    const next = recordAnswer(smelt, "scope-file", "README.md");
+    expect(smelt.answers).toHaveLength(0); // original unchanged
+    expect(next.answers).toHaveLength(1);
+    expect(next.answers[0]).toMatchObject({
+      questionId: "scope-file",
+      answer: "README.md",
+    });
+    expect(next.answers[0].recordedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+  it("rejects empty questionId", () => {
+    expect(() => recordAnswer({ answers: [] }, "", "x")).toThrow(/questionId required/);
+  });
+  it("rejects non-string answer", () => {
+    expect(() => recordAnswer({ answers: [] }, "q", 42)).toThrow(/answer must be a string/);
+  });
+  it("rejects null smelt", () => {
+    expect(() => recordAnswer(null, "q", "a")).toThrow(/smelt required/);
+  });
+});
+
+// ─── buildRecommendedDefault — strict no-fabrication ─────────────────
+
+describe("buildRecommendedDefault (primary: PROJECT-PRINCIPLES.md)", () => {
+  it("returns null when projectDir is absent", () => {
+    expect(buildRecommendedDefault("any", { defaultSource: "validation-gate" })).toBeNull();
+  });
+  it("returns null when defaultSource is null (question opted out)", () => {
+    expect(buildRecommendedDefault("any", { projectDir, defaultSource: null })).toBeNull();
+  });
+  it("returns null when memory empty (the key guardrail — NO FABRICATION)", () => {
+    const v = buildRecommendedDefault("validation", {
+      projectDir,
+      defaultSource: "validation-gate",
+    });
+    expect(v).toBeNull();
+  });
+  it("reads a validation-gate value from PROJECT-PRINCIPLES.md", () => {
+    const plansDir = resolve(projectDir, "docs", "plans");
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(
+      join(plansDir, "PROJECT-PRINCIPLES.md"),
+      "# Principles\n\n## Validation command\n\n```bash\nnpm test --run\n```\n",
+      "utf-8",
+    );
+    const v = buildRecommendedDefault("validation", {
+      projectDir,
+      defaultSource: "validation-gate",
+    });
+    expect(v).toBe("npm test --run");
+  });
+  it("reads a test-framework hint from PROJECT-PRINCIPLES.md", () => {
+    const plansDir = resolve(projectDir, "docs", "plans");
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(
+      join(plansDir, "PROJECT-PRINCIPLES.md"),
+      "# Principles\n\nTesting framework: vitest\n",
+      "utf-8",
+    );
+    expect(buildRecommendedDefault("tests", {
+      projectDir,
+      defaultSource: "test-framework",
+    })).toBe("vitest");
+  });
+});
+
+describe("buildRecommendedDefault (secondary: prior Phase-*.md)", () => {
+  it("reads a validation-gate from the most recent Phase plan", () => {
+    const plansDir = resolve(projectDir, "docs", "plans");
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(
+      join(plansDir, "Phase-05.md"),
+      "# Phase 5\n\n**Validation Gate**\n\n```bash\nnpm --prefix api test -- --run\n```\n",
+      "utf-8",
+    );
+    const v = buildRecommendedDefault("validation-gates", {
+      projectDir,
+      defaultSource: "validation-gate",
+    });
+    expect(v).toBe("npm --prefix api test -- --run");
+  });
+  it("returns null when no Phase-*.md contains the requested source", () => {
+    const plansDir = resolve(projectDir, "docs", "plans");
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(
+      join(plansDir, "Phase-05.md"),
+      "# Phase 5\n\nNothing relevant here.\n",
+      "utf-8",
+    );
+    const v = buildRecommendedDefault("stack-boundary", {
+      projectDir,
+      defaultSource: "stack",
+    });
+    expect(v).toBeNull();
+  });
+  it("reads slice-count from the most recent plan's slice headers", () => {
+    const plansDir = resolve(projectDir, "docs", "plans");
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(
+      join(plansDir, "Phase-07.md"),
+      "# Phase 7\n\n### Slice 1 — a\n\n### Slice 2 — b\n\n### Slice 3 — c\n",
+      "utf-8",
+    );
+    const v = buildRecommendedDefault("slice-count", {
+      projectDir,
+      defaultSource: "slice-count",
+    });
+    expect(v).toBe("3");
+  });
+  it("PROJECT-PRINCIPLES wins over Phase-*.md when both provide values", () => {
+    const plansDir = resolve(projectDir, "docs", "plans");
+    mkdirSync(plansDir, { recursive: true });
+    writeFileSync(
+      join(plansDir, "PROJECT-PRINCIPLES.md"),
+      "## Validation\n\n```\nmake verify\n```\n",
+      "utf-8",
+    );
+    writeFileSync(
+      join(plansDir, "Phase-01.md"),
+      "**Validation Gate**\n\n```\nnpm test\n```\n",
+      "utf-8",
+    );
+    const v = buildRecommendedDefault("validation", {
+      projectDir,
+      defaultSource: "validation-gate",
+    });
+    expect(v).toBe("make verify");
+  });
+});
+
+// ─── renderDraft — 6 mandatory blocks ────────────────────────────────
+
+describe("renderDraft — six mandatory blocks", () => {
+  it("emits all 6 mandatory block headings for a feature smelt", () => {
+    const md = renderDraft({
+      rawIdea: "add rate limiting",
+      lane: "feature",
+      source: "human",
+      status: "in-progress",
+      answers: [],
+      phaseName: null,
+    });
+    for (const heading of MANDATORY_BLOCKS) {
+      expect(md).toContain(heading);
+    }
+  });
+  it("emits all 6 mandatory block headings for a tweak smelt", () => {
+    const md = renderDraft({
+      rawIdea: "fix typo", lane: "tweak", source: "human", status: "in-progress", answers: [],
+    });
+    for (const heading of MANDATORY_BLOCKS) expect(md).toContain(heading);
+  });
+  it("emits all 6 mandatory block headings for a full smelt", () => {
+    const md = renderDraft({
+      rawIdea: "new phase", lane: "full", source: "human", status: "in-progress", answers: [],
+    });
+    for (const heading of MANDATORY_BLOCKS) expect(md).toContain(heading);
+    // Full lane also adds problem/stack/data/api/security
+    expect(md).toContain("## Problem & Success Metric");
+    expect(md).toContain("## Stack Boundary");
+    expect(md).toContain("## Data Model");
+    expect(md).toContain("## API Surface");
+    expect(md).toContain("## Security Posture");
+  });
+  it("surfaces {{TBD: <id>}} markers for every unanswered field", () => {
+    const md = renderDraft({
+      rawIdea: "add rate limiting",
+      lane: "feature",
+      source: "human",
+      status: "in-progress",
+      answers: [],
+    });
+    const tbds = extractUnresolvedFields(md);
+    expect(tbds.length).toBeGreaterThan(0);
+    // At least scope-files, validation-gates, rollback, forbidden-actions must be present
+    expect(tbds).toEqual(expect.arrayContaining([
+      "scope-files", "validation-gates", "rollback", "forbidden-actions",
+    ]));
+  });
+  it("does NOT emit {{TBD:}} for fields that have answers", () => {
+    const md = renderDraft({
+      rawIdea: "add rate limiting",
+      lane: "feature",
+      source: "human",
+      status: "in-progress",
+      answers: [
+        { questionId: "validation-gates", answer: "npm test" },
+        { questionId: "rollback", answer: "revert commit" },
+      ],
+    });
+    const tbds = extractUnresolvedFields(md);
+    expect(tbds).not.toContain("validation-gates");
+    expect(tbds).not.toContain("rollback");
+    // validation-gates answer should render in the Validation Gates block
+    expect(md).toMatch(/## Validation Gates\n+npm test/);
+  });
+  it("renders change manifest from scope-files answer as a bullet list", () => {
+    const md = renderDraft({
+      rawIdea: "x",
+      lane: "feature",
+      source: "human",
+      status: "in-progress",
+      answers: [
+        { questionId: "scope-files", answer: "src/a.ts\nsrc/b.ts" },
+      ],
+    });
+    expect(md).toMatch(/## Change Manifest\n+- src\/a\.ts\n- src\/b\.ts/);
+  });
+  it("stop conditions are boilerplate and do not use {{TBD:}}", () => {
+    const md = renderDraft({
+      rawIdea: "x", lane: "feature", source: "human", status: "in-progress", answers: [],
+    });
+    const stopBlock = md.split("## Stop Conditions")[1].split("##")[0];
+    expect(stopBlock).not.toContain("{{TBD:");
+    expect(stopBlock).toMatch(/Validation gate fails/);
+  });
+  it("includes the raw idea verbatim", () => {
+    const md = renderDraft({
+      rawIdea: "add rate limiting to /login",
+      lane: "feature", source: "human", status: "in-progress", answers: [],
+    });
+    expect(md).toContain("add rate limiting to /login");
+  });
+  it("uses feature-name answer as title when present", () => {
+    const md = renderDraft({
+      rawIdea: "x",
+      lane: "full",
+      source: "human",
+      status: "in-progress",
+      answers: [{ questionId: "feature-name", answer: "Billing Redesign" }],
+    });
+    expect(md).toMatch(/^# Billing Redesign/);
+  });
+  it("prefixes phase name in title when finalized", () => {
+    const md = renderDraft({
+      rawIdea: "add widget",
+      lane: "feature",
+      source: "human",
+      status: "finalized",
+      answers: [],
+      phaseName: "Phase-03",
+    });
+    expect(md).toMatch(/^# Phase-03: add widget/);
+  });
+});
+
+// ─── extractUnresolvedFields ─────────────────────────────────────────
+
+describe("extractUnresolvedFields", () => {
+  it("returns empty array when no markers present", () => {
+    expect(extractUnresolvedFields("# Clean plan\n\nAll fields resolved.")).toEqual([]);
+  });
+  it("extracts unique, ordered question ids", () => {
+    const md = "a {{TBD: foo}} b {{TBD: bar}} c {{TBD: foo}} d";
+    expect(extractUnresolvedFields(md)).toEqual(["foo", "bar"]);
+  });
+  it("handles non-string input defensively", () => {
+    expect(extractUnresolvedFields(null)).toEqual([]);
+    expect(extractUnresolvedFields(undefined)).toEqual([]);
+    expect(extractUnresolvedFields(42)).toEqual([]);
+  });
+  it("tolerates whitespace inside the marker", () => {
+    expect(extractUnresolvedFields("x {{TBD:   spaced-id   }} y")).toEqual(["spaced-id"]);
+  });
+});

--- a/pforge-mcp/tests/crucible-server.test.mjs
+++ b/pforge-mcp/tests/crucible-server.test.mjs
@@ -87,8 +87,23 @@ describe("inferLane", () => {
 // ─── getNextQuestion / renderDraftStub ───────────────────────────────
 
 describe("getNextQuestion", () => {
-  it("returns null in Slice 2 (Slice 3 replaces)", () => {
-    expect(getNextQuestion({ answers: [] })).toBeNull();
+  it("returns the first feature question for an empty feature smelt", () => {
+    const q = getNextQuestion({ lane: "feature", answers: [] });
+    expect(q).not.toBeNull();
+    expect(q.id).toBe("goal");
+    expect(q.questionIndex).toBe(1);
+    expect(q.totalQuestions).toBe(6);
+  });
+  it("returns null once every question is answered", () => {
+    const smelt = {
+      lane: "tweak",
+      answers: [
+        { questionId: "scope-file", answer: "x" },
+        { questionId: "validation", answer: "y" },
+        { questionId: "rollback", answer: "z" },
+      ],
+    };
+    expect(getNextQuestion(smelt)).toBeNull();
   });
 });
 
@@ -107,17 +122,17 @@ describe("renderDraftStub", () => {
     expect(out).toContain("**Source**: human");
     expect(out).toContain("## Raw Idea");
   });
-  it("renders answers section when present", () => {
+  it("renders interview log section when answers are present", () => {
     const out = renderDraftStub({
       rawIdea: "x",
       lane: "tweak",
       source: "human",
       status: "in-progress",
-      answers: [{ questionId: "1", answer: "yes" }],
+      answers: [{ questionId: "scope-file", answer: "yes" }],
       phaseName: null,
     });
-    expect(out).toContain("## Interview Answers");
-    expect(out).toContain("**1**: yes");
+    expect(out).toContain("## Interview Log");
+    expect(out).toContain("**scope-file** — yes");
   });
 });
 
@@ -154,7 +169,8 @@ describe("handleSubmit", () => {
     });
     expect(r.id).toMatch(/^[0-9a-f-]{36}$/);
     expect(r.recommendedLane).toBe("feature");
-    expect(r.firstQuestion).toBeNull();
+    expect(r.firstQuestion).not.toBeNull();
+    expect(r.firstQuestion.id).toBe("goal");
 
     const smelt = loadSmelt(r.id, projectDir);
     expect(smelt.lane).toBe("feature");
@@ -209,8 +225,8 @@ describe("handleAsk", () => {
     const { id } = handleSubmit({ rawIdea: "x", projectDir, hub: fakeHub });
     fakeHub.broadcasts.length = 0;
     const r = handleAsk({ id, projectDir, hub: fakeHub });
-    expect(r.done).toBe(true); // Slice 2 has no questions yet
-    expect(r.nextQuestion).toBeNull();
+    expect(r.done).toBe(false); // real banks now return questions
+    expect(r.nextQuestion).not.toBeNull();
     expect(typeof r.draftPreview).toBe("string");
     // No update event because nothing changed
     expect(fakeHub.broadcasts).toHaveLength(0);
@@ -223,9 +239,15 @@ describe("handleAsk", () => {
     expect(smelt.answers).toHaveLength(1);
     expect(smelt.answers[0].answer).toBe("first answer");
     expect(smelt.answers[0].recordedAt).toMatch(/^\d{4}-/);
+    // Slice 01.3: questionId is the real bank id, not a counter
+    expect(smelt.answers[0].questionId).toBe("goal");
     expect(fakeHub.broadcasts).toHaveLength(1);
     expect(fakeHub.broadcasts[0].type).toBe("crucible-smelt-updated");
-    expect(fakeHub.broadcasts[0].data).toMatchObject({ id, questionIndex: 1 });
+    expect(fakeHub.broadcasts[0].data).toMatchObject({
+      id,
+      questionIndex: 1,
+      totalQuestions: 6,
+    });
   });
   it("advances question counter across multiple answers", () => {
     const { id } = handleSubmit({ rawIdea: "x", projectDir, hub: fakeHub });
@@ -254,7 +276,9 @@ describe("handlePreview", () => {
     const r = handlePreview({ id, projectDir });
     expect(r.markdown).toContain("add a widget");
     expect(r.phaseName).toBeNull();
-    expect(r.unresolvedFields).toEqual([]);
+    // Slice 01.3: preview now surfaces {{TBD:}} question ids
+    expect(Array.isArray(r.unresolvedFields)).toBe(true);
+    expect(r.unresolvedFields.length).toBeGreaterThan(0);
   });
   it("throws structured error on unknown id", () => {
     expect(() => handlePreview({ id: "nope", projectDir }))


### PR DESCRIPTION
Third of 6 slices for Phase-CRUCIBLE-01 (v2.37.0). Replaces the Slice 01.2 interview + draft stubs with the real engine.

## New modules

### `pforge-mcp/crucible-interview.mjs`
- Three frozen question banks: `TWEAK_QUESTIONS` (3), `FEATURE_QUESTIONS` (6), `FULL_QUESTIONS` (12 — mirrors Step-0 specify prompt)
- `getNextQuestion(smelt, ctx)` — returns `{id, prompt, required, recommendedDefault, questionIndex, totalQuestions}` or `null` when done
- `buildRecommendedDefault(questionId, ctx)` — three-source fallback:
  1. `docs/plans/PROJECT-PRINCIPLES.md` (primary)
  2. Most-recent `docs/plans/Phase-*.md` files (secondary)
  3. `null` — **strict no-fabrication rule**, Design Commitment #3
- `recordAnswer(smelt, questionId, answer)` — pure, returns a patched smelt (immutable — original untouched)
- `totalQuestions(lane)` / `getQuestionBank(lane)` helpers

### `pforge-mcp/crucible-draft.mjs`
- `renderDraft(smelt)` assembles the phase-doc body with **6 mandatory blocks**:
  `## Scope Contract` · `## Slices` · `## Validation Gates` · `## Stop Conditions` · `## Rollback` · `## Anti-patterns & Forbidden Actions` · `## Change Manifest`
- Full-lane smelts also render Problem & Success Metric, Stack Boundary, Data Model, API Surface, Security Posture
- Unanswered fields emit `{{TBD: <question-id>}}` markers (17 present in source, ≥1 per gate)
- `extractUnresolvedFields(md)` — ordered, de-duped question ids for the preview UI
- `MANDATORY_BLOCKS` frozen export so tests can enforce the contract declaratively

## Wiring into `crucible-server.mjs`
- `handleSubmit` — `firstQuestion` is now a real lane-scoped question; event adds `totalQuestions`
- `handleAsk` — the question id is looked up server-side from the bank (never a client-supplied string → can't record answers for nonexistent questions); `crucible-smelt-updated` event now carries the real `totalQuestions`
- `handlePreview` — `unresolvedFields` populated via `extractUnresolvedFields`
- `handleFinalize` — uses `renderDraft` instead of the stub
- `renderDraftStub` kept as a deprecated back-compat alias

## Tests
- **NEW** `tests/crucible-interview.test.mjs` — **42 tests** covering:
  - Bank shape (ids unique, prompts present, required booleans)
  - `getNextQuestion` advance/stop/status-aware behaviour
  - `recordAnswer` immutability + input validation
  - Recommended-default resolver — all three source tiers + primary-wins-over-secondary
  - **Strict no-fabrication rule**: `recommendedDefault` is `null` when PROJECT-PRINCIPLES and Phase files yield nothing
  - All 6 mandatory blocks present per lane
  - `{{TBD:}}` markers surface only for unanswered fields
  - Title/phase-name prefixing; stop-conditions is never `{{TBD:}}`
  - `extractUnresolvedFields` edge cases (non-string input, whitespace)
- **UPDATED** `tests/crucible-server.test.mjs` — assertions adjusted for real questions (`questionId: "goal"`, `totalQuestions: 6` in events, populated `unresolvedFields` in preview)

## Validation gates (from plan)
```
npm --prefix pforge-mcp test -- --run tests/crucible-interview.test.mjs     # 42/42
npm --prefix pforge-mcp test -- --run                                       # 907/907
grep -c "{{TBD:" pforge-mcp/crucible-draft.mjs                              # 17  (>= 1)
grep -rn "// fabricate\|// guess" pforge-mcp/crucible-*.mjs                 # 0 hits
```

## Not yet in this slice (deferred to later slices)
- Bypass enforcement (`crucibleId:` frontmatter required on `forge_run_plan`) — **01.4**
- Grandfather migration for existing `Phase-*.md` — **01.4**
- Dashboard Crucible tab — **01.5**
- Plan Hardener handoff on finalize — **01.6**
- VERSION / CHANGELOG / package.json 2.37.0 bump — **01.6**

Cumulative progress: **3 of 6** slices complete.
