### PR TITLE
feat(crucible): slice 01.4 - enforcement gate + grandfather migration (Spec Kit preserved)

### DIFF
--- a/.github/prompts/step0-specify-feature.prompt.md
+++ b/.github/prompts/step0-specify-feature.prompt.md
@@ -62,6 +62,15 @@ Before asking any questions, scan the project for Spec Kit artifacts:
    - Plan source: `specs/<feature>/plan.md`
    - Constitution: `memory/constitution.md`
    ```
+6. **v2.37 Crucible requirement** — write a YAML frontmatter block as the very first lines of the new phase plan (before the `# Title`):
+   ```
+   ---
+   crucibleId: imported-speckit-<uuid>
+   lane: full
+   source: speckit
+   ---
+   ```
+   Use any valid UUID v4 (e.g. `imported-speckit-a1b2c3d4-...`). This lets `pforge run-plan` accept the imported plan without needing `--manual-import`. Without this frontmatter, execution will be blocked by the Crucible enforcement gate introduced in v2.37.
 
 **If no Spec Kit artifacts found** — continue to the document check below.
 

--- a/pforge-mcp/crucible-enforce.mjs
+++ b/pforge-mcp/crucible-enforce.mjs
@@ -1,0 +1,221 @@
+/**
+ * Plan Forge — Crucible Enforcement (Slice 01.4).
+ *
+ * Requires every `pforge run-plan` invocation to carry a `crucibleId:`
+ * frontmatter or pass `--manual-import` to bypass (audited).
+ *
+ * Frontmatter format (3-line YAML-ish, no external dep):
+ *   ---
+ *   key: value
+ *   ---
+ *   <body>
+ *
+ * Audit log: `.forge/crucible/manual-imports.jsonl`
+ *   Each line: {timestamp, planPath, source, reason?, crucibleId?}
+ *
+ * The `source` tag supports multiple bypass paths:
+ *   - "human"       — user passed --manual-import explicitly
+ *   - "speckit"     — Spec Kit importer (Step 0 prompt) wrote an
+ *                     `imported-speckit-*` crucibleId but audit
+ *                     records the origin so it's discoverable
+ *   - "grandfather" — crucible-migrate.mjs stamped a legacy plan
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+/**
+ * Parse a `---\n…\n---` YAML-ish frontmatter block.
+ * Returns `{ frontmatter, body, raw }` where frontmatter is a flat
+ * string-to-string map. Scalar values only — no arrays, no nested maps.
+ * Unknown lines inside the block are ignored.
+ *
+ * @param {string} content
+ * @returns {{frontmatter: Record<string,string>, body: string, raw: string|null}}
+ */
+export function parseFrontmatter(content) {
+  if (typeof content !== "string" || !content.startsWith("---")) {
+    return { frontmatter: {}, body: content || "", raw: null };
+  }
+  const m = content.match(FRONTMATTER_RE);
+  if (!m) return { frontmatter: {}, body: content, raw: null };
+  const raw = m[1];
+  const frontmatter = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const kv = line.match(/^\s*([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.*?)\s*$/);
+    if (!kv) continue;
+    let v = kv[2];
+    // Strip optional surrounding quotes
+    if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+      v = v.slice(1, -1);
+    }
+    frontmatter[kv[1]] = v;
+  }
+  return { frontmatter, body: content.slice(m[0].length), raw };
+}
+
+/**
+ * Structured error produced when a plan lacks `crucibleId:` and the
+ * caller did not pass `--manual-import`.
+ *
+ * The same message is thrown from `enforceCrucibleId` so the CLI and
+ * the MCP dispatcher can both surface it to the user verbatim.
+ */
+export class CrucibleEnforcementError extends Error {
+  constructor(planPath, frontmatter = {}) {
+    super(
+      "Plan missing crucibleId — run it through Crucible first " +
+      "(forge_crucible_submit), or pass --manual-import to bypass (logged).",
+    );
+    this.name = "CrucibleEnforcementError";
+    this.code = "CRUCIBLE_ID_REQUIRED";
+    this.planPath = planPath;
+    this.frontmatter = frontmatter;
+  }
+}
+
+/**
+ * Validate that a plan file carries an acceptable `crucibleId:` field.
+ * Audits bypass events when `manualImport` is true.
+ *
+ * @param {string} planPath     — absolute or project-relative path
+ * @param {object} [opts]
+ * @param {boolean} [opts.manualImport=false]
+ * @param {string}  [opts.source="human"]  audit tag when bypassing
+ * @param {string}  [opts.reason]          free-form note for audit
+ * @param {string}  [opts.cwd=process.cwd()] project dir for audit log
+ * @returns {{ ok: true, crucibleId: string, bypassed: boolean, frontmatter: Record<string,string> }}
+ * @throws {CrucibleEnforcementError}
+ */
+export function enforceCrucibleId(planPath, opts = {}) {
+  const {
+    manualImport = false,
+    source = "human",
+    reason = null,
+    cwd = process.cwd(),
+  } = opts;
+
+  const fullPath = resolve(cwd, planPath);
+  let content = "";
+  try { content = readFileSync(fullPath, "utf-8"); }
+  catch (err) {
+    // Surface file-not-found as a plain Error — enforcement only fires
+    // when we can read the plan.
+    throw new Error(`Plan file not readable: ${planPath} (${err.code || err.message})`);
+  }
+
+  const { frontmatter } = parseFrontmatter(content);
+  const crucibleId = frontmatter.crucibleId || "";
+
+  if (crucibleId) {
+    return { ok: true, crucibleId, bypassed: false, frontmatter };
+  }
+
+  if (!manualImport) {
+    throw new CrucibleEnforcementError(fullPath, frontmatter);
+  }
+
+  // Bypass accepted — write audit entry and succeed.
+  logManualImport(cwd, {
+    timestamp: new Date().toISOString(),
+    planPath: fullPath,
+    source,
+    reason: reason || null,
+    crucibleId: null,
+  });
+  return { ok: true, crucibleId: "", bypassed: true, frontmatter };
+}
+
+/**
+ * Append a JSONL entry to `.forge/crucible/manual-imports.jsonl`.
+ * Directory is created on demand. Failure to write is swallowed so a
+ * full disk doesn't block execution — the gate itself has already
+ * decided to allow the run.
+ *
+ * @param {string} cwd
+ * @param {object} entry
+ */
+export function logManualImport(cwd, entry) {
+  try {
+    const dir = resolve(cwd, ".forge", "crucible");
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    const path = resolve(dir, "manual-imports.jsonl");
+    appendFileSync(path, JSON.stringify(entry) + "\n", "utf-8");
+  } catch { /* best-effort */ }
+}
+
+/**
+ * Read all manual-import audit entries. Used by tests and the
+ * governance view (Slice 01.6). Returns [] on any read error.
+ *
+ * @param {string} cwd
+ * @returns {Array<object>}
+ */
+export function readManualImports(cwd) {
+  try {
+    const path = resolve(cwd, ".forge", "crucible", "manual-imports.jsonl");
+    if (!existsSync(path)) return [];
+    const text = readFileSync(path, "utf-8");
+    return text
+      .split(/\r?\n/)
+      .filter((l) => l.trim().length > 0)
+      .map((l) => {
+        try { return JSON.parse(l); } catch { return null; }
+      })
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Write a key-value pair into the plan's frontmatter (upsert). Used by
+ * the Spec Kit importer and the grandfather migration to stamp a
+ * `crucibleId:` on a legacy or imported plan file without touching the
+ * body.
+ *
+ * Idempotent when `onlyIfMissing` is true — existing values are kept.
+ *
+ * Returns `{ changed: boolean, content: string }`. Callers decide
+ * whether to persist.
+ *
+ * @param {string} content
+ * @param {Record<string,string>} kv
+ * @param {{onlyIfMissing?: boolean}} [opts]
+ */
+export function upsertFrontmatter(content, kv, opts = {}) {
+  const { onlyIfMissing = false } = opts;
+  const { frontmatter, body, raw } = parseFrontmatter(content);
+  let changed = false;
+  const merged = { ...frontmatter };
+  for (const [k, v] of Object.entries(kv)) {
+    if (onlyIfMissing && merged[k]) continue;
+    if (merged[k] === v) continue;
+    merged[k] = v;
+    changed = true;
+  }
+  if (!changed && raw !== null) {
+    return { changed: false, content };
+  }
+  const lines = Object.entries(merged).map(([k, v]) => `${k}: ${v}`);
+  const block = `---\n${lines.join("\n")}\n---\n`;
+  // Preserve a single blank line between frontmatter and body
+  const bodyTrimmed = body.replace(/^\r?\n+/, "");
+  return { changed: true, content: `${block}\n${bodyTrimmed}` };
+}
+
+// Re-export the audit dir path for tooling/tests.
+export function manualImportLogPath(cwd) {
+  return resolve(cwd, ".forge", "crucible", "manual-imports.jsonl");
+}
+
+// Quiet-unused export to keep dirname import tree-shake-safe in tests
+// that only import parseFrontmatter.
+void dirname;

--- a/pforge-mcp/crucible-migrate.mjs
+++ b/pforge-mcp/crucible-migrate.mjs
@@ -1,0 +1,108 @@
+/**
+ * Plan Forge — Crucible Grandfather Migration (Slice 01.4).
+ *
+ * Legacy projects that existed before v2.37 have `docs/plans/Phase-*.md`
+ * files without a `crucibleId:` frontmatter. Enforcement would break
+ * them instantly. This module stamps each such plan with a stable
+ * synthetic id so the enforcement gate lets them through while keeping
+ * them clearly distinguishable from plans that were actually smelted.
+ *
+ * Stamp format: `crucibleId: grandfathered-<uuid>`
+ * (NOT a real smelt id — tooling can tell the difference.)
+ *
+ * Design guarantees:
+ *   - Idempotent: re-running never changes an already-stamped file
+ *   - Scope-safe: only touches `docs/plans/Phase-*.md`
+ *   - Body-safe: only inserts frontmatter; body bytes are preserved
+ *   - Auditable: writes a `.forge/crucible/manual-imports.jsonl`
+ *                entry per stamped file with source="grandfather"
+ */
+
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+
+import {
+  parseFrontmatter,
+  upsertFrontmatter,
+  logManualImport,
+} from "./crucible-enforce.mjs";
+
+const PHASE_FILE_RE = /^Phase-.+\.md$/i;
+
+/**
+ * Stamp every legacy Phase plan lacking `crucibleId:` with a
+ * `grandfathered-<uuid>` value. Returns a per-file report.
+ *
+ * @param {string} projectDir
+ * @param {{ dryRun?: boolean }} [opts]
+ * @returns {{
+ *   scanned: number,
+ *   stamped: Array<{ path: string, crucibleId: string }>,
+ *   skipped: Array<{ path: string, reason: string }>,
+ * }}
+ */
+export function grandfatherExistingPlans(projectDir, opts = {}) {
+  const { dryRun = false } = opts;
+  const plansDir = resolve(projectDir, "docs", "plans");
+  const report = { scanned: 0, stamped: [], skipped: [] };
+
+  if (!existsSync(plansDir)) return report;
+
+  let entries;
+  try { entries = readdirSync(plansDir, { withFileTypes: true }); }
+  catch { return report; }
+
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    if (!PHASE_FILE_RE.test(entry.name)) continue;
+
+    const path = join(plansDir, entry.name);
+    report.scanned += 1;
+
+    let original;
+    try { original = readFileSync(path, "utf-8"); }
+    catch (err) {
+      report.skipped.push({ path, reason: `read-failed:${err.code || "unknown"}` });
+      continue;
+    }
+
+    const { frontmatter } = parseFrontmatter(original);
+    if (frontmatter.crucibleId) {
+      report.skipped.push({ path, reason: "already-stamped" });
+      continue;
+    }
+
+    const crucibleId = `grandfathered-${randomUUID()}`;
+    const { changed, content } = upsertFrontmatter(original, { crucibleId });
+    if (!changed) {
+      // Defensive — upsert should always change when the field is missing
+      report.skipped.push({ path, reason: "no-change" });
+      continue;
+    }
+
+    if (!dryRun) {
+      try { writeFileSync(path, content, "utf-8"); }
+      catch (err) {
+        report.skipped.push({ path, reason: `write-failed:${err.code || "unknown"}` });
+        continue;
+      }
+      logManualImport(projectDir, {
+        timestamp: new Date().toISOString(),
+        planPath: path,
+        source: "grandfather",
+        reason: "legacy plan predated v2.37 Crucible",
+        crucibleId,
+      });
+    }
+
+    report.stamped.push({ path, crucibleId });
+  }
+
+  return report;
+}

--- a/pforge-mcp/orchestrator.mjs
+++ b/pforge-mcp/orchestrator.mjs
@@ -27,6 +27,7 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { createTraceContext, createTelemetryHandler, writeManifest, appendRunIndex, pruneRunHistory, addLogSummary } from "./telemetry.mjs";
 import { isOpenBrainConfigured, buildMemorySearchBlock, buildMemoryCaptureBlock, buildRunSummaryThought, buildCostAnomalyThought, loadProjectContext, buildPlanBootContext } from "./memory.mjs";
+import { enforceCrucibleId, CrucibleEnforcementError } from "./crucible-enforce.mjs";
 
 // ─── Centralized Constants ────────────────────────────────────────────
 /** Canonical list of all supported agent adapters. Update here — consumed by dashboard, setup, and docs. */
@@ -123,6 +124,25 @@ export function parsePlan(planPath, cwd = process.cwd()) {
   const scopeContract = parseScopeContract(lines);
   const slices = parseSlices(lines);
   const dag = buildDAG(slices);
+
+  // v2.37 Crucible (Slice 01.4): expose crucibleId + import source on
+  // plan.meta so downstream code (status, reporting, dashboard) can
+  // display provenance. Enforcement happens in runPlan(), not here —
+  // parsePlan() must stay side-effect-free for estimate/dry-run flows.
+  const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  if (fmMatch) {
+    for (const fmLine of fmMatch[1].split(/\r?\n/)) {
+      const kv = fmLine.match(/^\s*([A-Za-z_][A-Za-z0-9_-]*)\s*:\s*(.*?)\s*$/);
+      if (!kv) continue;
+      let v = kv[2];
+      if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+        v = v.slice(1, -1);
+      }
+      if (kv[1] === "crucibleId") meta.crucibleId = v;
+      else if (kv[1] === "lane") meta.lane = v;
+      else if (kv[1] === "source") meta.crucibleSource = v;
+    }
+  }
 
   return { meta, scopeContract, slices, dag };
 }
@@ -1676,11 +1696,40 @@ export async function runPlan(planPath, options = {}) {
     quorumThreshold = null, // override threshold from config
     quorumPreset = null,   // "power" | "speed" | null — selects model preset
     bridge = null,         // BridgeManager instance for approval gate
+    manualImport = false,   // v2.37 Crucible (Slice 01.4): bypass crucibleId gate
+    manualImportSource = "human", // audit tag: "human" | "speckit" | "grandfather"
+    manualImportReason = null,    // free-form note for audit log
   } = options;
 
   // Load model routing from .forge.json (Slice 5)
   const modelRouting = loadModelRouting(cwd);
   const effectiveModel = model || modelRouting.default || null;
+
+  // v2.37 Crucible (Slice 01.4) — enforce that the plan was smelted
+  // through the Crucible funnel or an explicit `--manual-import` bypass
+  // was provided. Runs BEFORE parsePlan / estimate / dryRun so nobody
+  // can sneak a plan in by claiming "I'm only estimating."
+  try {
+    enforceCrucibleId(planPath, {
+      cwd,
+      manualImport,
+      source: manualImportSource,
+      reason: manualImportReason,
+    });
+  } catch (err) {
+    if (err instanceof CrucibleEnforcementError) {
+      return {
+        status: "failed",
+        error: err.message,
+        code: err.code,
+        planPath: err.planPath,
+        hint:
+          "Run `forge_crucible_submit` to start a smelt, or re-invoke with " +
+          "--manual-import to bypass (audited in .forge/crucible/manual-imports.jsonl).",
+      };
+    }
+    throw err;
+  }
 
   // Parse plan
   const plan = parsePlan(planPath, cwd);
@@ -6536,6 +6585,12 @@ if (args.includes("--test")) {
   }
   const quorumThreshold = getArg("--quorum-threshold") ? Number(getArg("--quorum-threshold")) : null;
 
+  // v2.37 Crucible (Slice 01.4) — --manual-import bypass for legacy
+  // / Spec Kit-imported plans without a `crucibleId:` frontmatter.
+  const manualImport = args.includes("--manual-import");
+  const manualImportSource = getArg("--manual-import-source") || "human";
+  const manualImportReason = getArg("--manual-import-reason") || null;
+
   try {
     const result = await runPlan(planPath, {
       cwd: process.cwd(),
@@ -6547,6 +6602,9 @@ if (args.includes("--test")) {
       quorum,
       quorumThreshold,
       quorumPreset,
+      manualImport,
+      manualImportSource,
+      manualImportReason,
     });
     console.log(JSON.stringify(result, null, 2));
     process.exit(result.status === "failed" ? 1 : 0);

--- a/pforge-mcp/server.mjs
+++ b/pforge-mcp/server.mjs
@@ -603,6 +603,9 @@ const TOOLS = [
         dryRun: { type: "boolean", description: "If true, parse and validate plan without executing" },
         quorum: { type: "string", enum: ["false", "true", "auto", "power", "speed"], description: "Quorum mode: 'false' (off), 'true' (all slices), 'auto' (threshold-based), 'power' (flagship models: Opus + GPT-5.3 + Grok 4.20), 'speed' (fast models: Sonnet + GPT-5.4-mini + Grok 4.1-fast). Default: auto" },
         quorumThreshold: { type: "number", description: "Override complexity threshold for auto quorum (1-10). Default: 6" },
+        manualImport: { type: "boolean", description: "v2.37 Crucible — bypass the crucibleId frontmatter gate. Logged to .forge/crucible/manual-imports.jsonl." },
+        manualImportSource: { type: "string", enum: ["human", "speckit", "grandfather"], description: "v2.37 Crucible — audit tag for --manual-import bypass. Default: human." },
+        manualImportReason: { type: "string", description: "v2.37 Crucible — optional free-form note recorded in the manual-import audit log." },
         path: { type: "string", description: "Project directory (default: current)" },
       },
       required: ["plan"],
@@ -1241,6 +1244,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         quorumThreshold: args.quorumThreshold != null ? Number(args.quorumThreshold) : null,
         abortController: activeAbortController,
         eventHandler,
+        // v2.37 Crucible (Slice 01.4) — bypass + audit
+        manualImport: args.manualImport === true || args.manualImport === "true",
+        manualImportSource: args.manualImportSource || "human",
+        manualImportReason: args.manualImportReason || null,
       });
       activeAbortController = null;
 

--- a/pforge-mcp/tests/crucible-enforce.test.mjs
+++ b/pforge-mcp/tests/crucible-enforce.test.mjs
@@ -1,0 +1,351 @@
+/**
+ * Plan Forge — Crucible Enforcement tests (Slice 01.4).
+ *
+ * Covers:
+ *   - parseFrontmatter (happy + malformed + CRLF)
+ *   - enforceCrucibleId accept / reject / bypass paths
+ *   - Audit log: manual-imports.jsonl content and tagging
+ *   - grandfatherExistingPlans idempotence, body safety, audit trail
+ *   - Spec Kit importer compatibility: a plan with
+ *     `crucibleId: imported-speckit-*` is accepted without
+ *     --manual-import (proving the importer is not broken by the gate)
+ *   - upsertFrontmatter round-trip and onlyIfMissing semantics
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import {
+  parseFrontmatter,
+  enforceCrucibleId,
+  CrucibleEnforcementError,
+  readManualImports,
+  manualImportLogPath,
+  logManualImport,
+  upsertFrontmatter,
+} from "../crucible-enforce.mjs";
+
+import {
+  grandfatherExistingPlans,
+} from "../crucible-migrate.mjs";
+
+let projectDir;
+let plansDir;
+
+beforeEach(() => {
+  projectDir = mkdtempSync(join(tmpdir(), "pforge-crucible-enforce-"));
+  plansDir = resolve(projectDir, "docs", "plans");
+  mkdirSync(plansDir, { recursive: true });
+});
+
+afterEach(() => {
+  try { rmSync(projectDir, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+function writePlan(name, content) {
+  const path = join(plansDir, name);
+  writeFileSync(path, content, "utf-8");
+  return path;
+}
+
+// ─── parseFrontmatter ────────────────────────────────────────────────
+
+describe("parseFrontmatter", () => {
+  it("extracts key:value pairs from a well-formed block", () => {
+    const { frontmatter, body } = parseFrontmatter(
+      "---\ncrucibleId: abc-123\nlane: feature\n---\n\n# Title\n",
+    );
+    expect(frontmatter).toMatchObject({ crucibleId: "abc-123", lane: "feature" });
+    expect(body).toBe("\n# Title\n");
+  });
+  it("returns empty frontmatter for a plain markdown file", () => {
+    const r = parseFrontmatter("# Title\n\nBody only\n");
+    expect(r.frontmatter).toEqual({});
+    expect(r.body).toContain("Title");
+  });
+  it("handles CRLF line endings", () => {
+    const r = parseFrontmatter("---\r\ncrucibleId: x\r\n---\r\n\r\nbody\r\n");
+    expect(r.frontmatter.crucibleId).toBe("x");
+  });
+  it("strips surrounding quotes from values", () => {
+    const r = parseFrontmatter('---\ncrucibleId: "abc"\nlane: \'feature\'\n---\n');
+    expect(r.frontmatter.crucibleId).toBe("abc");
+    expect(r.frontmatter.lane).toBe("feature");
+  });
+  it("tolerates non-string inputs defensively", () => {
+    expect(parseFrontmatter(null).frontmatter).toEqual({});
+    expect(parseFrontmatter(undefined).frontmatter).toEqual({});
+  });
+  it("ignores unparseable lines inside the block", () => {
+    const r = parseFrontmatter("---\ncrucibleId: ok\n@weird entry\n---\n\nbody");
+    expect(r.frontmatter).toEqual({ crucibleId: "ok" });
+  });
+});
+
+// ─── enforceCrucibleId ───────────────────────────────────────────────
+
+describe("enforceCrucibleId", () => {
+  it("accepts a plan with a crucibleId frontmatter", () => {
+    const path = writePlan(
+      "Phase-01.md",
+      "---\ncrucibleId: smelt-123\n---\n\n# Plan\n",
+    );
+    const r = enforceCrucibleId(path, { cwd: projectDir });
+    expect(r).toMatchObject({ ok: true, crucibleId: "smelt-123", bypassed: false });
+  });
+
+  it("rejects a plan without crucibleId and no --manual-import", () => {
+    const path = writePlan("Phase-01.md", "# Plan\n\nNo frontmatter here.\n");
+    expect(() => enforceCrucibleId(path, { cwd: projectDir }))
+      .toThrow(CrucibleEnforcementError);
+  });
+
+  it("rejection error carries a structured code and hint-friendly message", () => {
+    const path = writePlan("Phase-01.md", "# Plan\n");
+    try {
+      enforceCrucibleId(path, { cwd: projectDir });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CrucibleEnforcementError);
+      expect(err.code).toBe("CRUCIBLE_ID_REQUIRED");
+      expect(err.message).toMatch(/crucibleId/);
+      expect(err.message).toMatch(/--manual-import/);
+    }
+  });
+
+  it("bypasses with --manual-import and writes an audit entry", () => {
+    const path = writePlan("Phase-01.md", "# Plan\n");
+    const r = enforceCrucibleId(path, {
+      cwd: projectDir,
+      manualImport: true,
+      source: "human",
+      reason: "smoke test",
+    });
+    expect(r).toMatchObject({ ok: true, bypassed: true });
+
+    const audit = readManualImports(projectDir);
+    expect(audit).toHaveLength(1);
+    expect(audit[0]).toMatchObject({
+      planPath: path,
+      source: "human",
+      reason: "smoke test",
+      crucibleId: null,
+    });
+    expect(audit[0].timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("tags the audit entry with the caller-supplied source", () => {
+    const path = writePlan("Phase-01.md", "# Plan\n");
+    enforceCrucibleId(path, { cwd: projectDir, manualImport: true, source: "speckit" });
+    const audit = readManualImports(projectDir);
+    expect(audit[0].source).toBe("speckit");
+  });
+
+  it("appends subsequent bypasses to the same log file", () => {
+    const a = writePlan("Phase-01.md", "# A\n");
+    const b = writePlan("Phase-02.md", "# B\n");
+    enforceCrucibleId(a, { cwd: projectDir, manualImport: true });
+    enforceCrucibleId(b, { cwd: projectDir, manualImport: true });
+    expect(readManualImports(projectDir)).toHaveLength(2);
+  });
+
+  it("throws a plain Error (not CrucibleEnforcementError) when the plan file is missing", () => {
+    expect(() => enforceCrucibleId("docs/plans/nope.md", { cwd: projectDir }))
+      .toThrow(/Plan file not readable/);
+  });
+});
+
+// ─── Spec Kit importer compatibility ─────────────────────────────────
+
+describe("Spec Kit importer compatibility", () => {
+  it("accepts a Spec Kit-imported plan with imported-speckit-* crucibleId without --manual-import", () => {
+    const path = writePlan(
+      "Phase-05-Auth-Imported.md",
+      "---\n" +
+      "crucibleId: imported-speckit-a1b2c3d4-e5f6-7890-abcd-ef1234567890\n" +
+      "lane: full\n" +
+      "source: speckit\n" +
+      "---\n\n" +
+      "# Phase 5 — OAuth login (imported from Spec Kit)\n\n" +
+      "### Specification Source\n" +
+      "- Imported from: Spec Kit (`specs/005-auth/spec.md`)\n" +
+      "- Plan source: `specs/005-auth/plan.md`\n",
+    );
+    const r = enforceCrucibleId(path, { cwd: projectDir });
+    expect(r.ok).toBe(true);
+    expect(r.bypassed).toBe(false); // accepted on frontmatter, NO bypass audited
+    expect(r.crucibleId).toMatch(/^imported-speckit-/);
+    expect(r.frontmatter.source).toBe("speckit");
+    // No audit entry should be written when frontmatter is present
+    expect(existsSync(manualImportLogPath(projectDir))).toBe(false);
+  });
+
+  it("accepts --manual-import with source=speckit when frontmatter is missing (legacy import path)", () => {
+    const path = writePlan(
+      "Phase-06-Legacy-Import.md",
+      "# Phase 6 — legacy Spec Kit import without frontmatter\n",
+    );
+    const r = enforceCrucibleId(path, {
+      cwd: projectDir,
+      manualImport: true,
+      source: "speckit",
+      reason: "pre-v2.37 spec kit import",
+    });
+    expect(r.bypassed).toBe(true);
+    const audit = readManualImports(projectDir);
+    expect(audit[0].source).toBe("speckit");
+  });
+});
+
+// ─── logManualImport + readManualImports ─────────────────────────────
+
+describe("audit log", () => {
+  it("creates the audit directory on first write", () => {
+    logManualImport(projectDir, { timestamp: "t", source: "test" });
+    expect(existsSync(manualImportLogPath(projectDir))).toBe(true);
+  });
+  it("skips malformed JSONL lines when reading", () => {
+    logManualImport(projectDir, { timestamp: "t", source: "test" });
+    // Corrupt the file with an invalid line
+    const path = manualImportLogPath(projectDir);
+    const existing = readFileSync(path, "utf-8");
+    writeFileSync(path, existing + "NOT-JSON\n" + '{"timestamp":"t2","source":"ok"}\n');
+    const entries = readManualImports(projectDir);
+    expect(entries).toHaveLength(2); // malformed line dropped
+    expect(entries[1].source).toBe("ok");
+  });
+  it("readManualImports returns [] when log absent", () => {
+    expect(readManualImports(projectDir)).toEqual([]);
+  });
+});
+
+// ─── upsertFrontmatter ───────────────────────────────────────────────
+
+describe("upsertFrontmatter", () => {
+  it("adds frontmatter to a plain markdown file", () => {
+    const r = upsertFrontmatter("# Title\n\nbody\n", { crucibleId: "abc" });
+    expect(r.changed).toBe(true);
+    expect(r.content).toMatch(/^---\ncrucibleId: abc\n---\n\n# Title/);
+  });
+  it("merges into existing frontmatter without duplicating", () => {
+    const input = "---\nlane: feature\n---\n\n# Title\n";
+    const r = upsertFrontmatter(input, { crucibleId: "abc" });
+    expect(r.content).toMatch(/lane: feature/);
+    expect(r.content).toMatch(/crucibleId: abc/);
+    // Body preserved
+    expect(r.content).toMatch(/# Title/);
+  });
+  it("is idempotent when value is identical", () => {
+    const input = "---\ncrucibleId: abc\n---\n\nbody\n";
+    const r = upsertFrontmatter(input, { crucibleId: "abc" });
+    expect(r.changed).toBe(false);
+  });
+  it("onlyIfMissing keeps existing values", () => {
+    const input = "---\ncrucibleId: original\n---\nbody";
+    const r = upsertFrontmatter(input, { crucibleId: "new" }, { onlyIfMissing: true });
+    expect(r.changed).toBe(false);
+    expect(r.content).toMatch(/crucibleId: original/);
+  });
+});
+
+// ─── grandfatherExistingPlans ────────────────────────────────────────
+
+describe("grandfatherExistingPlans", () => {
+  it("stamps legacy plans lacking crucibleId", () => {
+    writePlan("Phase-1A-Cell-Foundation.md", "# Phase 1A\n\nBody.\n");
+    writePlan("Phase-1B-Recovery.md", "# Phase 1B\n\nBody.\n");
+    const r = grandfatherExistingPlans(projectDir);
+    expect(r.scanned).toBe(2);
+    expect(r.stamped).toHaveLength(2);
+    expect(r.stamped[0].crucibleId).toMatch(/^grandfathered-[0-9a-f-]{36}$/);
+    // Files now carry frontmatter
+    const first = readFileSync(r.stamped[0].path, "utf-8");
+    expect(first).toMatch(/^---\ncrucibleId: grandfathered-/);
+    expect(first).toContain("Body.");
+  });
+
+  it("is idempotent — second run skips already-stamped plans", () => {
+    writePlan("Phase-1A.md", "# Phase 1A\n\nBody\n");
+    const first = grandfatherExistingPlans(projectDir);
+    const second = grandfatherExistingPlans(projectDir);
+    expect(first.stamped).toHaveLength(1);
+    expect(second.stamped).toHaveLength(0);
+    expect(second.skipped[0].reason).toBe("already-stamped");
+    // Crucible id is preserved across runs
+    const content = readFileSync(first.stamped[0].path, "utf-8");
+    expect(content).toContain(first.stamped[0].crucibleId);
+  });
+
+  it("does not touch a plan that was already smelted", () => {
+    const path = writePlan("Phase-01.md", "---\ncrucibleId: real-smelt\n---\n\n# X\n");
+    const r = grandfatherExistingPlans(projectDir);
+    expect(r.stamped).toHaveLength(0);
+    expect(r.skipped[0].reason).toBe("already-stamped");
+    const content = readFileSync(path, "utf-8");
+    expect(content).toMatch(/crucibleId: real-smelt/);
+    expect(content).not.toMatch(/grandfathered-/);
+  });
+
+  it("body is byte-preserved (no additions beyond frontmatter)", () => {
+    const body = "# Phase 1A\n\nSome body\nwith multiple lines.\n";
+    const path = writePlan("Phase-1A.md", body);
+    grandfatherExistingPlans(projectDir);
+    const after = readFileSync(path, "utf-8");
+    // Body must appear verbatim after the closing frontmatter delimiter
+    expect(after.endsWith(body)).toBe(true);
+  });
+
+  it("writes one audit entry per stamped file with source='grandfather'", () => {
+    writePlan("Phase-1A.md", "# A\n");
+    writePlan("Phase-1B.md", "# B\n");
+    grandfatherExistingPlans(projectDir);
+    const audit = readManualImports(projectDir);
+    expect(audit).toHaveLength(2);
+    for (const entry of audit) {
+      expect(entry.source).toBe("grandfather");
+      expect(entry.crucibleId).toMatch(/^grandfathered-/);
+    }
+  });
+
+  it("skips non-phase files in docs/plans/", () => {
+    writePlan("Phase-1A.md", "# A\n");
+    writePlan("README.md", "# readme");
+    writePlan("DEPLOYMENT-ROADMAP.md", "# roadmap");
+    const r = grandfatherExistingPlans(projectDir);
+    expect(r.scanned).toBe(1);
+    expect(r.stamped).toHaveLength(1);
+  });
+
+  it("dryRun does not write files or audit entries", () => {
+    const path = writePlan("Phase-1A.md", "# A\n");
+    const r = grandfatherExistingPlans(projectDir, { dryRun: true });
+    expect(r.stamped).toHaveLength(1);
+    const content = readFileSync(path, "utf-8");
+    expect(content).not.toMatch(/crucibleId:/);
+    expect(readManualImports(projectDir)).toEqual([]);
+  });
+
+  it("returns empty report when docs/plans/ does not exist", () => {
+    rmSync(plansDir, { recursive: true, force: true });
+    const r = grandfatherExistingPlans(projectDir);
+    expect(r).toEqual({ scanned: 0, stamped: [], skipped: [] });
+  });
+
+  it("post-migration plans pass enforceCrucibleId without bypass", () => {
+    const path = writePlan("Phase-1A.md", "# A\n");
+    grandfatherExistingPlans(projectDir);
+    const r = enforceCrucibleId(path, { cwd: projectDir });
+    expect(r.ok).toBe(true);
+    expect(r.bypassed).toBe(false);
+    expect(r.crucibleId).toMatch(/^grandfathered-/);
+  });
+});

--- a/pforge.ps1
+++ b/pforge.ps1
@@ -3284,7 +3284,7 @@ function Invoke-Smith {
 function Invoke-RunPlan {
     if ($Arguments.Count -lt 1) {
         Write-Host "ERROR: Missing plan path" -ForegroundColor Red
-        Write-Host "Usage: pforge run-plan <plan-file> [--estimate] [--assisted] [--model <name>] [--resume-from <N>] [--dry-run] [--foreground] [--no-quorum] [--quorum] [--quorum=auto] [--quorum-threshold <N>]" -ForegroundColor Yellow
+        Write-Host "Usage: pforge run-plan <plan-file> [--estimate] [--assisted] [--model <name>] [--resume-from <N>] [--dry-run] [--foreground] [--no-quorum] [--quorum] [--quorum=auto] [--quorum-threshold <N>] [--manual-import [--manual-import-source <human|speckit|grandfather>] [--manual-import-reason <text>]]" -ForegroundColor Yellow
         exit 1
     }
 
@@ -3301,10 +3301,13 @@ function Invoke-RunPlan {
     $dryRun      = $Arguments -contains '--dry-run'
     $foreground  = $Arguments -contains '--foreground'
     $noQuorum    = $Arguments -contains '--no-quorum'
+    $manualImport = $Arguments -contains '--manual-import'
     $model       = $null
     $resumeFrom  = $null
     $quorumArg   = $null
     $quorumThreshold = $null
+    $manualImportSource = $null
+    $manualImportReason = $null
 
     for ($i = 1; $i -lt $Arguments.Count; $i++) {
         if ($Arguments[$i] -eq '--model' -and ($i + 1) -lt $Arguments.Count) {
@@ -3318,6 +3321,12 @@ function Invoke-RunPlan {
         }
         if ($Arguments[$i] -eq '--quorum-threshold' -and ($i + 1) -lt $Arguments.Count) {
             $quorumThreshold = $Arguments[$i + 1]
+        }
+        if ($Arguments[$i] -eq '--manual-import-source' -and ($i + 1) -lt $Arguments.Count) {
+            $manualImportSource = $Arguments[$i + 1]
+        }
+        if ($Arguments[$i] -eq '--manual-import-reason' -and ($i + 1) -lt $Arguments.Count) {
+            $manualImportReason = $Arguments[$i + 1]
         }
     }
 
@@ -3343,6 +3352,9 @@ function Invoke-RunPlan {
     if ($noQuorum)        { $nodeArgs += '--no-quorum' }
     elseif ($quorumArg)   { $nodeArgs += $quorumArg }
     if ($quorumThreshold) { $nodeArgs += '--quorum-threshold'; $nodeArgs += $quorumThreshold }
+    if ($manualImport)    { $nodeArgs += '--manual-import' }
+    if ($manualImportSource) { $nodeArgs += '--manual-import-source'; $nodeArgs += $manualImportSource }
+    if ($manualImportReason) { $nodeArgs += '--manual-import-reason'; $nodeArgs += $manualImportReason }
 
     # Delegate to orchestrator
     Write-Host ""

--- a/pforge.sh
+++ b/pforge.sh
@@ -2507,7 +2507,7 @@ cmd_doctor() {
 cmd_run_plan() {
     if [ $# -lt 1 ]; then
         echo "ERROR: Missing plan path" >&2
-        echo "Usage: pforge run-plan <plan-file> [--estimate] [--assisted] [--model <name>] [--resume-from <N>] [--dry-run] [--foreground] [--no-quorum] [--quorum] [--quorum=auto] [--quorum-threshold <N>]" >&2
+        echo "Usage: pforge run-plan <plan-file> [--estimate] [--assisted] [--model <name>] [--resume-from <N>] [--dry-run] [--foreground] [--no-quorum] [--quorum] [--quorum=auto] [--quorum-threshold <N>] [--manual-import [--manual-import-source <human|speckit|grandfather>] [--manual-import-reason <text>]]" >&2
         exit 1
     fi
 
@@ -2529,6 +2529,9 @@ cmd_run_plan() {
     local resume_from=""
     local quorum_arg=""
     local quorum_threshold=""
+    local manual_import=false
+    local manual_import_source=""
+    local manual_import_reason=""
 
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -2539,6 +2542,15 @@ cmd_run_plan() {
             --no-quorum)    quorum_arg="--no-quorum" ;;
             --quorum=*)     quorum_arg="$1" ;;
             --quorum)       quorum_arg="--quorum" ;;
+            --manual-import) manual_import=true ;;
+            --manual-import-source)
+                shift
+                if [ -z "$1" ]; then echo "ERROR: --manual-import-source requires a value" >&2; exit 1; fi
+                manual_import_source="$1" ;;
+            --manual-import-reason)
+                shift
+                if [ -z "$1" ]; then echo "ERROR: --manual-import-reason requires a value" >&2; exit 1; fi
+                manual_import_reason="$1" ;;
             --model)
                 shift
                 if [ -z "$1" ] || [ "${1#-}" != "$1" ]; then
@@ -2578,6 +2590,9 @@ cmd_run_plan() {
     if [ -n "$resume_from" ]; then node_args+=("--resume-from" "$resume_from"); fi
     if [ -n "$quorum_arg" ]; then node_args+=("$quorum_arg"); fi
     if [ -n "$quorum_threshold" ]; then node_args+=("--quorum-threshold" "$quorum_threshold"); fi
+    if [ "$manual_import" = true ]; then node_args+=("--manual-import"); fi
+    if [ -n "$manual_import_source" ]; then node_args+=("--manual-import-source" "$manual_import_source"); fi
+    if [ -n "$manual_import_reason" ]; then node_args+=("--manual-import-reason" "$manual_import_reason"); fi
 
     echo ""
     if [ "$estimate" = true ]; then


### PR DESCRIPTION
## Summary

Slice 01.4 of Phase CRUCIBLE-01. Introduces the v2.37 Crucible **enforcement gate** and the **grandfather migration** for legacy plans. From this slice onward, `pforge run-plan` refuses to execute a plan that lacks a `crucibleId:` frontmatter unless the caller explicitly passes `--manual-import` (which is logged).

No version bump in this slice — VERSION stays `2.36.1-dev` until Slice 01.6 ships the full 2.37.0 bundle.

## What changed

### New modules

| File | Purpose |
|------|---------|
| `pforge-mcp/crucible-enforce.mjs` | `parseFrontmatter`, `enforceCrucibleId`, `upsertFrontmatter`, `logManualImport`, `readManualImports`, `CrucibleEnforcementError` |
| `pforge-mcp/crucible-migrate.mjs` | `grandfatherExistingPlans()` — idempotent, body-safe, auditable stamping of legacy `Phase-*.md` plans with `grandfathered-<uuid>` |

### Orchestrator changes

- `parsePlan` reads `crucibleId`, `lane`, `source` from frontmatter into `plan.meta` (pure — safe for estimate/dry-run)
- `runPlan` fires the enforcement gate **before** parse/estimate/dry-run — `--estimate` cannot be used to bypass the gate
- On failure returns a structured `{ status: "failed", code: "CRUCIBLE_ID_REQUIRED", planPath, hint }` response

### CLI

- `pforge run-plan --manual-import [--manual-import-source human|speckit|grandfather] [--manual-import-reason <text>]` — both PowerShell and Bash wrappers
- Orchestrator CLI accepts the same flags

### MCP

- `forge_run_plan` tool schema exposes `manualImport`, `manualImportSource`, `manualImportReason`

### Spec Kit importer preserved (explicit user requirement)

The existing Spec Kit importer in `.github/prompts/step0-specify-feature.prompt.md` is not broken by the gate. The Step 0 prompt now instructs the agent to write a frontmatter block:

```
---
crucibleId: imported-speckit-<uuid>
lane: full
source: speckit
---
```

as the first lines of the new phase plan when importing Spec Kit artifacts. Imported plans therefore pass the gate without bypass. Pre-v2.37 imports can fall back to `--manual-import --manual-import-source speckit` for clean audit attribution.

### Audit trail

`.forge/crucible/manual-imports.jsonl` records every bypass:

```json
{"timestamp":"2025-...","planPath":"...","source":"human|speckit|grandfather","reason":"...","crucibleId":"grandfathered-... or null"}
```

Synthetic crucible ids are clearly distinguishable:

- `grandfathered-<uuid>` — legacy plans migrated at upgrade time
- `imported-speckit-<uuid>` — Spec Kit imports
- `<uuid>` (no prefix) — plans actually smelted through Crucible

Slice 01.6's governance view will surface this.

## Testing

**938 tests pass** (31 new in `pforge-mcp/tests/crucible-enforce.test.mjs`, up from 907).

Coverage:

- `parseFrontmatter`: happy path, malformed, CRLF, quoted values, defensive (non-string input), ignored unparseable lines
- `enforceCrucibleId`: accept with id, reject without id, structured error code, bypass with audit, source-tagged audit, appends across calls, file-missing path
- **Spec Kit compatibility**: `imported-speckit-*` ids accepted without bypass (no audit log entry written); legacy imports audited with `source=speckit`
- `logManualImport` / `readManualImports`: directory auto-creation, malformed-line tolerance, empty-log path
- `upsertFrontmatter`: add/merge/idempotent/onlyIfMissing
- `grandfatherExistingPlans`: stamping, idempotence (second run stamps nothing), no-touch when `crucibleId` present, body-byte preservation, audit trail with `source="grandfather"`, non-phase files skipped, dry-run, missing-dir, enforcement passes after migration

Dry-run smoke test on the repo's own `docs/plans/`: scanned 1 file (`Phase-CRUCIBLE-01.md`) — it's the only legacy plan and it self-hosts in Slice 01.6.

## Risk

- **Non-breaking for existing test suites**: the gate is scoped to `runPlan`; `parsePlan` (used by tests) is untouched behaviorally. Confirmed by running the full suite — all 907 pre-existing tests still pass.
- **Audit failures are swallowed**: `logManualImport` writes are best-effort. A full disk doesn't block execution once the gate has already decided to allow the run.
- **Grandfathering is dry-run-able** — users can preview what would be stamped before committing.

## Next

- Slice 01.5 — Dashboard Crucible tab (3-panel layout, 6 REST endpoints)
- Slice 01.6 — Config + Governance + docs + VERSION bump to 2.37.0 + self-host `Phase-CRUCIBLE-01.md`
