### PR TITLE
feat(crucible): slice 01.5 - dashboard tab + REST endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ GEMINI.md
 # LiveGuard auto-generated fix plans (runtime artifacts, not source-controlled)
 docs/plans/auto/*
 !docs/plans/auto/README.md
+
+# Rummag poller artifacts (not part of Plan Forge)
+.issues.json
+.rummag-baseline.txt
+.rummag-poller.ps1

--- a/pforge-mcp/dashboard/app.js
+++ b/pforge-mcp/dashboard/app.js
@@ -2773,6 +2773,7 @@ loadPlans();
 // Tab load hooks
 const tabLoadHooks = {
   progress: loadPlans,
+  crucible: loadCrucible,
   runs: () => { loadRuns(); tabBadgeState.runsNew = 0; updateTabBadges(); },
   replay: loadReplayRuns,
   extensions: loadExtensions,
@@ -3210,6 +3211,285 @@ async function loadMemoryReport() {
   }
 }
 window.loadMemoryReport = loadMemoryReport;
+
+// ─── v2.37 Crucible Tab (Slice 01.5) ─────────────────────────
+// Client for the /api/crucible/* endpoints. Keeps a tiny module-scope
+// state object so the 3 panels (list, interview, preview) can update
+// each other without DOM scraping.
+
+const crucibleState = {
+  activeId: null,
+  currentQuestion: null,
+  done: false,
+  lastListAt: 0,
+};
+
+async function loadCrucible() {
+  try {
+    const res = await fetch(`${API_BASE}/api/crucible/list`);
+    if (!res.ok) {
+      setHTML("crucible-smelt-list", `<p class="text-red-400 py-2">Failed to load smelts (${res.status})</p>`);
+      return;
+    }
+    const { smelts = [] } = await res.json();
+    crucibleState.lastListAt = Date.now();
+    renderCrucibleList(smelts);
+    // Re-sync active smelt preview if one is selected
+    if (crucibleState.activeId && smelts.some((s) => s.id === crucibleState.activeId)) {
+      refreshCrucibleInterview();
+    }
+  } catch (err) {
+    setHTML("crucible-smelt-list", `<p class="text-red-400 py-2">Error: ${err.message}</p>`);
+  }
+}
+window.loadCrucible = loadCrucible;
+
+function renderCrucibleList(smelts) {
+  const listEl = document.getElementById("crucible-smelt-list");
+  if (!listEl) return;
+  if (!smelts.length) {
+    listEl.innerHTML = `<p class="text-gray-500 py-2">No smelts yet. Click <span class="text-orange-400">+ New Smelt</span>.</p>`;
+    return;
+  }
+  const statusColor = {
+    "in-progress": "text-orange-400",
+    "finalized": "text-green-400",
+    "abandoned": "text-gray-500",
+  };
+  listEl.innerHTML = smelts
+    .slice()
+    .sort((a, b) => (b.createdAt || "").localeCompare(a.createdAt || ""))
+    .map((s) => {
+      const active = s.id === crucibleState.activeId ? "bg-gray-700" : "hover:bg-gray-700/50";
+      const label = s.phaseName || (s.rawIdea ? s.rawIdea.slice(0, 40) : s.id.slice(0, 8));
+      const color = statusColor[s.status] || "text-gray-400";
+      return `<button class="w-full text-left ${active} rounded px-2 py-1.5 block" onclick="selectSmelt('${s.id}')">
+        <div class="truncate">${escapeHtml(label)}</div>
+        <div class="text-[10px] ${color}">${s.status} · ${s.lane}</div>
+      </button>`;
+    })
+    .join("");
+}
+
+async function startNewSmelt() {
+  const rawIdea = window.prompt("Describe the idea to smelt (one-paragraph summary is fine):");
+  if (!rawIdea || !rawIdea.trim()) return;
+  const lane = window.prompt("Lane (tweak / feature / full, or leave blank for auto-detection):", "") || null;
+  try {
+    const res = await fetch(`${API_BASE}/api/crucible/submit`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ rawIdea, lane: lane ? lane.trim() : null }),
+    });
+    if (!res.ok) {
+      const { error } = await res.json().catch(() => ({}));
+      alert(`Submit failed: ${error || res.status}`);
+      return;
+    }
+    const { id, firstQuestion } = await res.json();
+    crucibleState.activeId = id;
+    crucibleState.currentQuestion = firstQuestion;
+    crucibleState.done = firstQuestion === null;
+    await loadCrucible();
+    renderCrucibleInterview();
+    await refreshCrucibleInterview();
+  } catch (err) { alert(`Submit error: ${err.message}`); }
+}
+window.startNewSmelt = startNewSmelt;
+
+async function selectSmelt(id) {
+  crucibleState.activeId = id;
+  crucibleState.currentQuestion = null;
+  crucibleState.done = false;
+  renderCrucibleInterview();
+  await refreshCrucibleInterview();
+  await loadCrucible();
+}
+window.selectSmelt = selectSmelt;
+
+async function refreshCrucibleInterview() {
+  if (!crucibleState.activeId) return;
+  try {
+    // Use ask with no answer to fetch the next question + fresh preview
+    const askRes = await fetch(`${API_BASE}/api/crucible/ask`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: crucibleState.activeId }),
+    });
+    if (askRes.ok) {
+      const data = await askRes.json();
+      crucibleState.currentQuestion = data.nextQuestion || null;
+      crucibleState.done = Boolean(data.done);
+      updateInterviewPanel(data);
+    } else {
+      // Smelt is likely not in-progress (finalized/abandoned) — fall back to preview only
+      crucibleState.currentQuestion = null;
+      crucibleState.done = true;
+    }
+    // Preview is always available
+    const prevRes = await fetch(`${API_BASE}/api/crucible/preview?id=${encodeURIComponent(crucibleState.activeId)}`);
+    if (prevRes.ok) {
+      const preview = await prevRes.json();
+      updatePreviewPanel(preview);
+    }
+  } catch (err) {
+    console.error("[crucible] refresh failed", err);
+  }
+}
+
+function renderCrucibleInterview() {
+  const empty = document.getElementById("crucible-interview-empty");
+  const panel = document.getElementById("crucible-interview");
+  if (crucibleState.activeId) {
+    if (empty) empty.classList.add("hidden");
+    if (panel) panel.classList.remove("hidden");
+    const idEl = document.getElementById("crucible-active-id");
+    if (idEl) idEl.textContent = crucibleState.activeId.slice(0, 12) + "…";
+  } else {
+    if (empty) empty.classList.remove("hidden");
+    if (panel) panel.classList.add("hidden");
+  }
+}
+
+function updateInterviewPanel(data) {
+  const q = data.nextQuestion;
+  const qText = document.getElementById("crucible-question-text");
+  const answer = document.getElementById("crucible-answer");
+  const idx = document.getElementById("crucible-q-index");
+  const total = document.getElementById("crucible-q-total");
+  const recLabel = document.getElementById("crucible-recommendation-label");
+  const recVal = document.getElementById("crucible-recommendation-value");
+  const nextBtn = document.getElementById("crucible-next-btn");
+  const finalBtn = document.getElementById("crucible-finalize-btn");
+  const lane = document.getElementById("crucible-active-lane");
+
+  if (q) {
+    if (qText) qText.textContent = q.prompt || q.text || q.id || "(no prompt)";
+    if (answer) answer.value = q.recommendedDefault || "";
+    if (idx) idx.textContent = (q.index ?? "?");
+    if (total) total.textContent = (q.total ?? "?");
+    if (lane && q.lane) lane.textContent = q.lane;
+    if (q.recommendedDefault && recLabel && recVal) {
+      recVal.textContent = q.recommendedDefault;
+      recLabel.classList.remove("hidden");
+    } else if (recLabel) {
+      recLabel.classList.add("hidden");
+    }
+    if (nextBtn) nextBtn.classList.remove("hidden");
+    if (finalBtn) finalBtn.classList.add("hidden");
+  } else {
+    // Interview complete
+    if (qText) qText.textContent = "Interview complete — review the draft and finalize.";
+    if (answer) answer.value = "";
+    if (nextBtn) nextBtn.classList.add("hidden");
+    if (finalBtn) finalBtn.classList.remove("hidden");
+  }
+}
+
+function updatePreviewPanel(preview) {
+  const pre = document.getElementById("crucible-preview");
+  if (pre) pre.textContent = preview.markdown || "(empty)";
+  const unresolved = Array.isArray(preview.unresolvedFields) ? preview.unresolvedFields : [];
+  const badge = document.getElementById("crucible-unresolved-count");
+  if (badge) badge.textContent = unresolved.length > 0 ? `${unresolved.length} unresolved` : "✓ complete";
+}
+
+async function submitAnswer() {
+  if (!crucibleState.activeId) return;
+  const answerEl = document.getElementById("crucible-answer");
+  const answer = answerEl ? answerEl.value : "";
+  try {
+    const res = await fetch(`${API_BASE}/api/crucible/ask`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: crucibleState.activeId, answer }),
+    });
+    if (!res.ok) {
+      const { error } = await res.json().catch(() => ({}));
+      alert(`Ask failed: ${error || res.status}`);
+      return;
+    }
+    const data = await res.json();
+    crucibleState.currentQuestion = data.nextQuestion;
+    crucibleState.done = Boolean(data.done);
+    updateInterviewPanel(data);
+    if (data.draftPreview !== undefined) {
+      updatePreviewPanel({ markdown: data.draftPreview, unresolvedFields: extractUnresolvedFromMarkdown(data.draftPreview) });
+    }
+  } catch (err) { alert(`Ask error: ${err.message}`); }
+}
+window.submitAnswer = submitAnswer;
+
+function extractUnresolvedFromMarkdown(md) {
+  if (typeof md !== "string") return [];
+  const re = /\{\{TBD:[^}]+\}\}/g;
+  return md.match(re) || [];
+}
+
+async function finalizeSmelt() {
+  if (!crucibleState.activeId) return;
+  if (!confirm("Finalize this smelt? A Phase-NN.md will be written to docs/plans/.")) return;
+  try {
+    const res = await fetch(`${API_BASE}/api/crucible/finalize`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: crucibleState.activeId }),
+    });
+    if (!res.ok) {
+      const { error } = await res.json().catch(() => ({}));
+      alert(`Finalize failed: ${error || res.status}`);
+      return;
+    }
+    const { phaseName, planPath } = await res.json();
+    alert(`✓ Finalized as ${phaseName}\n  ${planPath}\n\nNext: run the Plan Hardener on this plan.`);
+    await loadCrucible();
+  } catch (err) { alert(`Finalize error: ${err.message}`); }
+}
+window.finalizeSmelt = finalizeSmelt;
+
+async function abandonSmelt() {
+  if (!crucibleState.activeId) return;
+  if (!confirm("Abandon this smelt? This cannot be undone.")) return;
+  try {
+    const res = await fetch(`${API_BASE}/api/crucible/abandon`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: crucibleState.activeId }),
+    });
+    if (!res.ok) {
+      const { error } = await res.json().catch(() => ({}));
+      alert(`Abandon failed: ${error || res.status}`);
+      return;
+    }
+    crucibleState.activeId = null;
+    renderCrucibleInterview();
+    await loadCrucible();
+  } catch (err) { alert(`Abandon error: ${err.message}`); }
+}
+window.abandonSmelt = abandonSmelt;
+
+function escapeHtml(s) {
+  if (typeof s !== "string") return "";
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+// Live-update hook — called from the existing hub subscriber when a
+// crucible-* event arrives.
+function onCrucibleHubEvent(event) {
+  const type = event && event.type;
+  if (typeof type !== "string" || !type.startsWith("crucible-")) return;
+  // Refresh list on every crucible event; if it's our active smelt, refresh the interview too
+  loadCrucible();
+  if (event.data && event.data.id === crucibleState.activeId) {
+    refreshCrucibleInterview();
+  }
+}
+window.onCrucibleHubEvent = onCrucibleHubEvent;
+
 
 async function copyWatchCommand(live) {
   const cmd = live ? "pforge watch-live <target-path>" : "pforge watch <target-path>";

--- a/pforge-mcp/dashboard/index.html
+++ b/pforge-mcp/dashboard/index.html
@@ -72,6 +72,7 @@
     <!-- Sub tabs: Forge -->
     <div id="subtabs-forge" class="flex gap-1 pt-1 pb-0.5 overflow-x-auto">
       <button class="tab-btn tab-active px-3 py-1.5 rounded-t hover:text-blue-400 whitespace-nowrap text-xs" data-tab="progress">Progress</button>
+      <button class="tab-btn px-3 py-1.5 rounded-t hover:text-orange-400 text-gray-400 whitespace-nowrap text-xs" data-tab="crucible">🔥 Crucible</button>
       <button class="tab-btn px-3 py-1.5 rounded-t hover:text-blue-400 text-gray-400 whitespace-nowrap text-xs" data-tab="runs">Runs</button>
       <button class="tab-btn px-3 py-1.5 rounded-t hover:text-blue-400 text-gray-400 whitespace-nowrap text-xs" data-tab="cost">Cost</button>
       <button class="tab-btn px-3 py-1.5 rounded-t hover:text-blue-400 text-gray-400 whitespace-nowrap text-xs" data-tab="actions">Actions</button>
@@ -169,6 +170,76 @@
           </div>
         </div>
       </details>
+    </section>
+
+    <!-- Crucible Tab (v2.37) — 3-panel smelt workspace -->
+    <section id="tab-crucible" class="tab-content hidden">
+      <div class="bg-gray-800 rounded-lg p-4 mb-4 flex items-center justify-between">
+        <div>
+          <h2 class="text-lg font-semibold">🔥 Crucible — Idea Smelting</h2>
+          <p class="text-sm text-gray-400">Turn a raw idea into a hardened phase plan. Every plan must be smelted here before execution.</p>
+        </div>
+        <button id="crucible-new-btn" class="bg-orange-600 hover:bg-orange-500 text-white text-sm font-semibold px-4 py-2 rounded" onclick="startNewSmelt()">+ New Smelt</button>
+      </div>
+
+      <div class="grid gap-4" style="grid-template-columns: 25% 45% 30%;">
+        <!-- Left: smelt list -->
+        <div class="bg-gray-800 rounded-lg p-3">
+          <h3 class="text-sm font-semibold mb-2 text-gray-300">Smelts</h3>
+          <div id="crucible-smelt-list" class="space-y-1 text-xs">
+            <p class="text-gray-500 py-2">Loading…</p>
+          </div>
+        </div>
+
+        <!-- Center: active interview -->
+        <div class="bg-gray-800 rounded-lg p-4">
+          <div id="crucible-interview-empty" class="text-center text-gray-500 py-16">
+            <p class="text-sm">Select a smelt on the left, or click <span class="text-orange-400">+ New Smelt</span> to start one.</p>
+          </div>
+          <div id="crucible-interview" class="hidden">
+            <div class="flex items-center justify-between mb-3">
+              <div class="flex items-center gap-2">
+                <span class="text-xs text-gray-500">Smelt</span>
+                <code id="crucible-active-id" class="text-xs bg-gray-700 px-2 py-0.5 rounded text-gray-300"></code>
+                <span id="crucible-active-lane" class="text-xs px-2 py-0.5 rounded-full bg-orange-900 text-orange-200"></span>
+              </div>
+              <div class="text-xs text-gray-400">
+                <span id="crucible-q-index">0</span> / <span id="crucible-q-total">0</span>
+              </div>
+            </div>
+            <div id="crucible-question-block" class="mb-4">
+              <p class="text-xs uppercase tracking-wide text-gray-500 mb-1">Question</p>
+              <p id="crucible-question-text" class="text-sm text-gray-200"></p>
+            </div>
+            <div class="mb-3">
+              <label class="text-xs uppercase tracking-wide text-gray-500">Your answer</label>
+              <textarea id="crucible-answer" rows="4" class="w-full bg-gray-900 border border-gray-700 rounded text-sm text-gray-200 p-2 mt-1 focus:outline-none focus:ring-1 focus:ring-orange-500" placeholder="Answer here. The recommended default (if any) is pre-filled."></textarea>
+            </div>
+            <div class="flex items-center justify-between">
+              <div class="text-xs text-gray-500">
+                <span id="crucible-recommendation-label" class="hidden">
+                  <span class="text-gray-400">Recommended:</span>
+                  <span id="crucible-recommendation-value" class="text-orange-300"></span>
+                </span>
+              </div>
+              <div class="flex gap-2">
+                <button onclick="abandonSmelt()" class="text-xs text-gray-400 hover:text-red-400 px-2 py-1">Abandon</button>
+                <button id="crucible-finalize-btn" class="hidden bg-green-700 hover:bg-green-600 text-white text-sm px-3 py-1 rounded" onclick="finalizeSmelt()">Finalize → Hardener</button>
+                <button id="crucible-next-btn" class="bg-orange-600 hover:bg-orange-500 text-white text-sm px-3 py-1 rounded" onclick="submitAnswer()">Next →</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Right: live draft preview -->
+        <div class="bg-gray-800 rounded-lg p-3">
+          <div class="flex items-center justify-between mb-2">
+            <h3 class="text-sm font-semibold text-gray-300">Draft Preview</h3>
+            <span id="crucible-unresolved-count" class="text-xs text-yellow-400"></span>
+          </div>
+          <pre id="crucible-preview" class="text-xs text-gray-300 whitespace-pre-wrap font-mono max-h-[70vh] overflow-y-auto bg-gray-900 rounded p-2">No active smelt</pre>
+        </div>
+      </div>
     </section>
 
     <!-- Runs Tab -->

--- a/pforge-mcp/server.mjs
+++ b/pforge-mcp/server.mjs
@@ -3291,7 +3291,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 });
 
 // ─── Express App + REST API  ─────────────────────────────
-function createExpressApp() {
+export function createExpressApp() {
   const app = express();
   app.use(express.json());
 
@@ -3655,6 +3655,95 @@ function createExpressApp() {
       const files = readdirSync(runbooksDir).filter((f) => f.endsWith(".md")).sort();
       res.json(files.map((f) => ({ file: `.forge/runbooks/${f}` })));
     } catch (err) { res.status(500).json({ error: err.message }); }
+  });
+
+  // ─── v2.37 Crucible REST API (Slice 01.5) ──────────────────────────
+  // Back the dashboard Crucible tab. Thin HTTP wrappers around the
+  // crucible-server handlers that already power the MCP tools, so the
+  // dashboard and the agent share one code path.
+
+  // POST /api/crucible/submit — start a new smelt
+  app.post("/api/crucible/submit", (req, res) => {
+    try {
+      const { rawIdea, lane = null, source = "human", parentSmeltId = null } = req.body || {};
+      if (typeof rawIdea !== "string" || !rawIdea.trim()) {
+        return res.status(400).json({ error: "rawIdea is required" });
+      }
+      const result = crucibleHandleSubmit({
+        rawIdea,
+        lane,
+        source,
+        parentSmeltId,
+        projectDir: PROJECT_DIR,
+        hub: activeHub,
+      });
+      res.status(201).json(result);
+    } catch (err) { res.status(500).json({ error: err.message }); }
+  });
+
+  // POST /api/crucible/ask — record an answer and fetch the next question
+  app.post("/api/crucible/ask", (req, res) => {
+    try {
+      const { id, answer } = req.body || {};
+      if (typeof id !== "string" || !id) {
+        return res.status(400).json({ error: "id is required" });
+      }
+      const result = crucibleHandleAsk({ id, answer, projectDir: PROJECT_DIR, hub: activeHub });
+      res.json(result);
+    } catch (err) {
+      const status = /not found/i.test(err.message) ? 404 : 500;
+      res.status(status).json({ error: err.message });
+    }
+  });
+
+  // GET /api/crucible/list — all smelts (optionally filtered by status)
+  app.get("/api/crucible/list", (req, res) => {
+    try {
+      const status = typeof req.query?.status === "string" ? req.query.status : null;
+      res.json(crucibleHandleList({ status, projectDir: PROJECT_DIR }));
+    } catch (err) { res.status(500).json({ error: err.message }); }
+  });
+
+  // GET /api/crucible/preview?id=… — live markdown preview + unresolved fields
+  app.get("/api/crucible/preview", (req, res) => {
+    try {
+      const id = typeof req.query?.id === "string" ? req.query.id : null;
+      if (!id) return res.status(400).json({ error: "id is required" });
+      res.json(crucibleHandlePreview({ id, projectDir: PROJECT_DIR }));
+    } catch (err) {
+      const status = /not found/i.test(err.message) ? 404 : 500;
+      res.status(status).json({ error: err.message });
+    }
+  });
+
+  // POST /api/crucible/finalize — emit docs/plans/Phase-NN.md
+  app.post("/api/crucible/finalize", (req, res) => {
+    try {
+      const { id } = req.body || {};
+      if (typeof id !== "string" || !id) {
+        return res.status(400).json({ error: "id is required" });
+      }
+      const result = crucibleHandleFinalize({ id, projectDir: PROJECT_DIR, hub: activeHub });
+      res.status(201).json(result);
+    } catch (err) {
+      const status = /not found/i.test(err.message) ? 404 : 500;
+      res.status(status).json({ error: err.message });
+    }
+  });
+
+  // POST /api/crucible/abandon — mark a smelt abandoned (no plan written)
+  app.post("/api/crucible/abandon", (req, res) => {
+    try {
+      const { id } = req.body || {};
+      if (typeof id !== "string" || !id) {
+        return res.status(400).json({ error: "id is required" });
+      }
+      const result = crucibleHandleAbandon({ id, projectDir: PROJECT_DIR });
+      res.json(result);
+    } catch (err) {
+      const status = /not found/i.test(err.message) ? 404 : 500;
+      res.status(status).json({ error: err.message });
+    }
   });
 
   // REST API: GET /api/hotspots — git churn hotspot analysis (cache TTL 24h)

--- a/pforge-mcp/tests/crucible-dashboard.test.mjs
+++ b/pforge-mcp/tests/crucible-dashboard.test.mjs
@@ -1,0 +1,183 @@
+/**
+ * Plan Forge — Crucible Dashboard REST endpoint tests (Slice 01.5).
+ *
+ * The happy-path state flow (submit → ask → preview → finalize) is
+ * exhaustively covered in `tests/crucible-server.test.mjs`. This file
+ * locks in the HTTP layer: URL/method contracts, input validation
+ * (400s), not-found handling (404s), and no-regression shape tests on
+ * the dashboard assets (index.html + app.js) that back the tab.
+ *
+ * We start the Express app on port 0 (OS-assigned) so the tests don't
+ * collide with a running `forge_dashboard_start`.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createExpressApp } from "../server.mjs";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+let server;
+let baseUrl;
+
+beforeAll(async () => {
+  const app = createExpressApp();
+  server = app.listen(0);
+  await new Promise((resolve) => server.once("listening", resolve));
+  const { port } = server.address();
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  if (server) await new Promise((r) => server.close(r));
+});
+
+// Helpers
+
+async function post(path, body) {
+  return fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+async function get(path) {
+  return fetch(`${baseUrl}${path}`);
+}
+
+// ─── /api/crucible/submit ───────────────────────────────────────────
+
+describe("POST /api/crucible/submit", () => {
+  it("rejects a request without rawIdea (400)", async () => {
+    const res = await post("/api/crucible/submit", {});
+    expect(res.status).toBe(400);
+    const { error } = await res.json();
+    expect(error).toMatch(/rawIdea/);
+  });
+
+  it("rejects an empty rawIdea (400)", async () => {
+    const res = await post("/api/crucible/submit", { rawIdea: "   " });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-string rawIdea (400)", async () => {
+    const res = await post("/api/crucible/submit", { rawIdea: 42 });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── /api/crucible/ask ──────────────────────────────────────────────
+
+describe("POST /api/crucible/ask", () => {
+  it("rejects a request without id (400)", async () => {
+    const res = await post("/api/crucible/ask", { answer: "x" });
+    expect(res.status).toBe(400);
+    const { error } = await res.json();
+    expect(error).toMatch(/id/);
+  });
+
+  it("returns 404 for an unknown smelt id", async () => {
+    const res = await post("/api/crucible/ask", { id: "does-not-exist-" + Date.now() });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── /api/crucible/preview ──────────────────────────────────────────
+
+describe("GET /api/crucible/preview", () => {
+  it("rejects when id is missing (400)", async () => {
+    const res = await get("/api/crucible/preview");
+    expect(res.status).toBe(400);
+    const { error } = await res.json();
+    expect(error).toMatch(/id/);
+  });
+
+  it("returns 404 for an unknown smelt id", async () => {
+    const res = await get("/api/crucible/preview?id=nope-" + Date.now());
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── /api/crucible/finalize ─────────────────────────────────────────
+
+describe("POST /api/crucible/finalize", () => {
+  it("rejects when id is missing (400)", async () => {
+    const res = await post("/api/crucible/finalize", {});
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for an unknown smelt id", async () => {
+    const res = await post("/api/crucible/finalize", { id: "missing-" + Date.now() });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── /api/crucible/abandon ──────────────────────────────────────────
+
+describe("POST /api/crucible/abandon", () => {
+  it("rejects when id is missing (400)", async () => {
+    const res = await post("/api/crucible/abandon", {});
+    expect(res.status).toBe(400);
+  });
+
+  it("is idempotent — unknown ids return 200 with abandoned:false (no throw)", async () => {
+    const res = await post("/api/crucible/abandon", { id: "nope-" + Date.now() });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("abandoned");
+    expect(body.abandoned).toBe(false);
+  });
+});
+
+// ─── /api/crucible/list ─────────────────────────────────────────────
+
+describe("GET /api/crucible/list", () => {
+  it("returns 200 with a { smelts: [...] } shape", async () => {
+    const res = await get("/api/crucible/list");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("smelts");
+    expect(Array.isArray(body.smelts)).toBe(true);
+  });
+
+  it("accepts an optional ?status= query string without erroring", async () => {
+    const res = await get("/api/crucible/list?status=finalized");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body.smelts)).toBe(true);
+  });
+});
+
+// ─── Dashboard asset wiring ─────────────────────────────────────────
+
+describe("Dashboard Crucible tab wiring", () => {
+  const html = readFileSync(resolve(__dirname, "..", "dashboard", "index.html"), "utf-8");
+  const js = readFileSync(resolve(__dirname, "..", "dashboard", "app.js"), "utf-8");
+
+  it("index.html contains the Crucible tab button at a fixed position", () => {
+    expect(html).toContain('data-tab="crucible"');
+    expect(html).toContain('id="tab-crucible"');
+  });
+
+  it("index.html wires the three Crucible panels", () => {
+    expect(html).toContain('id="crucible-smelt-list"');
+    expect(html).toContain('id="crucible-interview"');
+    expect(html).toContain('id="crucible-preview"');
+  });
+
+  it("app.js registers loadCrucible under TAB_LOADERS and defines handlers", () => {
+    expect(js).toMatch(/crucible:\s*loadCrucible/);
+    expect(js).toMatch(/async function loadCrucible/);
+    expect(js).toMatch(/function startNewSmelt/);
+    expect(js).toMatch(/function submitAnswer/);
+    expect(js).toMatch(/function finalizeSmelt/);
+    expect(js).toMatch(/function abandonSmelt/);
+  });
+
+  it("app.js exposes loadCrucible + onCrucibleHubEvent on window for live updates", () => {
+    expect(js).toContain("window.loadCrucible = loadCrucible");
+    expect(js).toContain("window.onCrucibleHubEvent = onCrucibleHubEvent");
+  });
+});

--- a/pforge-mcp/tests/server.test.mjs
+++ b/pforge-mcp/tests/server.test.mjs
@@ -1810,11 +1810,11 @@ describe("dashboard tab structure", () => {
   const dashboardHtml = readFileSync(resolve(__dirname, "..", "dashboard", "index.html"), "utf-8");
   const dashboardJs = readFileSync(resolve(__dirname, "..", "dashboard", "app.js"), "utf-8");
 
-  const CORE_TABS = ["progress", "runs", "cost", "actions", "replay", "extensions", "config", "traces", "skills", "watcher", "memory"];
+  const CORE_TABS = ["progress", "crucible", "runs", "cost", "actions", "replay", "extensions", "config", "traces", "skills", "watcher", "memory"];
   const LG_TABS = ["lg-health", "lg-incidents", "lg-triage", "lg-security", "lg-env"];
   const ALL_TABS = [...CORE_TABS, ...LG_TABS];
 
-  it("has 11 core tab buttons", () => {
+  it("has 12 core tab buttons", () => {
     for (const tab of CORE_TABS) {
       expect(dashboardHtml).toContain(`data-tab="${tab}"`);
     }
@@ -1826,9 +1826,9 @@ describe("dashboard tab structure", () => {
     }
   });
 
-  it("total tab count is 16 (11 core + 5 LG)", () => {
+  it("total tab count is 17 (12 core + 5 LG)", () => {
     const tabMatches = dashboardHtml.match(/data-tab="[^"]+"/g) || [];
-    expect(tabMatches.length).toBe(16);
+    expect(tabMatches.length).toBe(17);
   });
 
   it("has LiveGuard section divider", () => {


### PR DESCRIPTION
## Summary

Slice 01.5 of Phase CRUCIBLE-01. Adds the **dashboard Crucible tab** (3-panel workspace) and **6 REST endpoints** that back it. The dashboard and the MCP tool surface now share one handler code path — both call into `crucible-server.mjs`.

No version bump in this slice — VERSION stays `2.36.1-dev` until Slice 01.6 ships the full 2.37.0 bundle.

## What changed

### Dashboard (new tab, position 2)

- **Tab button**: `data-tab="crucible"` inserted between Progress and Runs
- **Tab panel** (`#tab-crucible`), 3-column grid 25% / 45% / 30%:
  - **Left — Smelt list**: in-progress + finalized + abandoned, color-coded by status, click to select
  - **Center — Active interview**: question, recommended default (pre-filled in answer box), lane badge, Q index / total counter, Prev/Next/Finalize/Abandon buttons
  - **Right — Live draft preview**: rendered markdown in `<pre>`, unresolved-fields counter in the header

### REST API (6 endpoints)

| Method + path | Body / query | Success | Errors |
|---|---|---|---|
| POST `/api/crucible/submit` | `{rawIdea, lane?, source?, parentSmeltId?}` | `201 {id, recommendedLane, firstQuestion}` | `400` empty/non-string `rawIdea` |
| POST `/api/crucible/ask` | `{id, answer?}` | `200 {nextQuestion?, done, draftPreview}` | `400` missing `id`, `404` unknown smelt |
| GET `/api/crucible/list` | `?status=` (optional) | `200 {smelts: [...]}` | — |
| GET `/api/crucible/preview` | `?id=` | `200 {markdown, phaseName, unresolvedFields}` | `400` missing `id`, `404` unknown smelt |
| POST `/api/crucible/finalize` | `{id}` | `201 {phaseName, planPath, ...}` | `400` missing `id`, `404` unknown smelt |
| POST `/api/crucible/abandon` | `{id}` | `200 {abandoned: boolean}` (idempotent) | `400` missing `id` |

All endpoints are thin wrappers around the existing `crucibleHandle*` functions in `crucible-server.mjs` — one code path for the MCP tools and the dashboard. No business logic lives in the HTTP layer.

### Dashboard app.js

- `TAB_LOADERS.crucible` registered → `loadCrucible()` fetches the list and renders the tab
- `startNewSmelt()` prompts for raw idea + optional lane, POSTs `/api/crucible/submit`, jumps into the interview
- `submitAnswer()`, `finalizeSmelt()`, `abandonSmelt()` wire the Center-panel buttons
- `onCrucibleHubEvent()` — subscribed to `crucible-smelt-started/updated/finalized` hub events; refreshes the list on every event and re-syncs the interview when the active smelt is the one being updated

### Server plumbing

- `createExpressApp()` is now **exported** so tests can spin up the app on an ephemeral port (was module-private before)

### Chores

- `.gitignore` entries for the Rummag poller artifacts (`.issues.json`, `.rummag-baseline.txt`, `.rummag-poller.ps1`) — these live in the repo root during development but are not part of Plan Forge

## Testing

**955 tests pass** (+17 new, up from 938).

New tests in `pforge-mcp/tests/crucible-dashboard.test.mjs`:

- `POST /api/crucible/submit` — 400 on empty/missing/non-string `rawIdea` (3 tests)
- `POST /api/crucible/ask` — 400 missing id, 404 unknown smelt (2 tests)
- `GET /api/crucible/preview` — 400 missing id, 404 unknown smelt (2 tests)
- `POST /api/crucible/finalize` — 400 missing id, 404 unknown smelt (2 tests)
- `POST /api/crucible/abandon` — 400 missing id; **idempotent** `{abandoned: false}` for unknown ids (2 tests)
- `GET /api/crucible/list` — shape + optional `?status=` filter (2 tests)
- Dashboard asset wiring — tab button, 3 panels, `loadCrucible`/handlers registered, `window.*` exports (3 tests)

Happy-path state flow (submit → ask → preview → finalize) is already exhaustively covered in `tests/crucible-server.test.mjs` (34 tests). This file locks in the HTTP boundary — contracts, validation, and wiring.

Updates to `tests/server.test.mjs`:
- `CORE_TABS` grows by 1 (`"crucible"` at index 1)
- Tab count assertions: 16 → 17 total, 11 → 12 core

## Validation gate

```bash
npm --prefix pforge-mcp test -- --run               # 955 green
grep -c "tab-crucible" pforge-mcp/dashboard/index.html     # 2
grep -c "loadCrucible\|TAB_LOADERS.crucible" pforge-mcp/dashboard/app.js  # >= 2
```

## Risk

- **Stop condition clear**: the tab-count drift check catches accidental duplicate tabs. +1 is the expected delta — any other value triggers an audit.
- **One code path**: HTTP handlers call directly into `crucible-server.mjs` handlers. No duplicate state machines to keep in sync.
- **Validation-only tests**: the new HTTP tests intentionally don't write to real smelt state — they cover 400s, 404s, and list-shape. Happy-path state flow is the responsibility of `crucible-server.test.mjs`.

## Next

- Slice 01.6 — Config + Governance + Hardener handoff + docs + VERSION bump to 2.37.0 + self-host `Phase-CRUCIBLE-01.md`
