### PR TITLE
docs(plans): wire Tempering arc into L1/L2/L3 memory

### DIFF
--- a/docs/plans/Phase-TEMPER-01.md
+++ b/docs/plans/Phase-TEMPER-01.md
@@ -68,6 +68,12 @@ load-bearing.
 - Hub events `tempering-scan-started` + `tempering-scan-completed`
   (consumed by dashboard)
 - Telemetry via existing `emitToolTelemetry`
+- **L3 capture** on `tempering-scan-completed` via existing
+  `captureMemory()` helper — tags `tempering`, `scan`, `<stack>`,
+  `<status>`; payload: gap summary (no file contents). Never blocks
+  the scanner; OpenBrain outages fall through to
+  `.forge/openbrain-queue.jsonl` as usual. See arc doc
+  §"L3 semantic memory (OpenBrain) integration".
 
 **Slice 01.2 — Dashboard surface + watcher anomalies**
 

--- a/docs/plans/Phase-TEMPER-02.md
+++ b/docs/plans/Phase-TEMPER-02.md
@@ -63,6 +63,10 @@ language-agnostic.
 - New MCP tool `forge_tempering_run` — executes enabled scanners per
   `config.scanners`, writes `.forge/tempering/<runId>.json`, emits
   `tempering-run-*` hub events per scanner
+- **L3 capture** on `tempering-run-completed` via `captureMemory()` —
+  tags `tempering`, `run`, `<stack>`, `<verdict>`; payload: scanner
+  mix + verdict + coverage-vs-minima deltas. See arc doc
+  §"L3 semantic memory (OpenBrain) integration".
 - Parallelism: respects `config.execution.parallelism` (`"cpu-count"` default)
 - **Regression-first ordering**: when `config.execution.regressionFirst`
   is true, run tests covering files changed since last green scan first

--- a/docs/plans/Phase-TEMPER-04.md
+++ b/docs/plans/Phase-TEMPER-04.md
@@ -80,6 +80,11 @@ This phase gives tempering that same glance — using vision-capable LLMs,
     TEMPER-06), ignore-once
 - Cost-aware scheduling: visual-analyzer only runs against pages in the
   investigate band, not the full baseline every run
+- **L3 capture** on every quorum decision (pass, fail, or inconclusive)
+  via `captureMemory()` — tags `tempering`, `visual-regression`,
+  `<verdict>`, `quorum:<n-of-m>`; payload: per-model verdict +
+  explanation snippet + page URL. **No images** — screenshots stay
+  in L2. See arc doc §"L3 semantic memory (OpenBrain) integration".
 - Tests — ~25 assertions
 
 ### Out of scope

--- a/docs/plans/Phase-TEMPER-05.md
+++ b/docs/plans/Phase-TEMPER-05.md
@@ -110,6 +110,16 @@ enterprise defaults, they're table stakes.
 - New anomaly `tempering-flake-detected`
 - New anomaly `tempering-perf-regression`
 - Dashboard Tempering tab gets three new subsections
+- **L3 capture** via `captureMemory()` at three moments:
+  - Flake-confirmed (≥ 3 of N runs) — tags `tempering`, `flake`,
+    `<scanner>`, `<testName>`
+  - Perf regression confirmed (2 consecutive runs) — tags `tempering`,
+    `perf-regression`, `<endpoint-or-page>`
+  - Mutation score below minimum — tags `tempering`, `mutation-gap`,
+    `<layer>`
+  Cross-project recall is the point: "this test has been flaky
+  elsewhere too" informs classification in TEMPER-06. See arc doc
+  §"L3 semantic memory (OpenBrain) integration".
 - Tests — ~30 assertions
 
 ### Out of scope

--- a/docs/plans/Phase-TEMPER-06.md
+++ b/docs/plans/Phase-TEMPER-06.md
@@ -73,6 +73,13 @@ trackers.
   `.forge/tempering/<runId>.json#infraFixes[]` with no external side
   effects.
 - Hub event `tempering-bug-registered`
+- **L3 capture** on `forge_bug_register` (real-bug only — infra
+  classifications are never captured) via `captureMemory()` — tags
+  `tempering-bug`, `<scanner>`, `<severity>`, `confidence-source:
+  <rule|llm>`; payload: classification rationale + affected-files
+  summary (no code, no screenshots). Feeds future classifier
+  confidence across projects. See arc doc §"L3 semantic memory
+  (OpenBrain) integration".
 - Dashboard **Bug Registry tab** — list view with filters, detail
   view with evidence / screenshots / repro / linked plan
 - Tests — ~40 assertions covering every rule branch + classifier
@@ -129,6 +136,12 @@ trackers.
     validation comment to external tracker (if configured)
   - On fail → appends to bug's `validationAttempts[]`, keeps open
 - Hub event `tempering-bug-validated-fixed`
+- **L3 capture** on `forge_bug_validate_fix` pass — tags
+  `tempering-fix`, `<bugCategory>`, `<outcome>`; payload: bug
+  classification + fix-plan slug + scanner(s) re-run + validation
+  verdict. Answers "what fixes have worked for this class of bug
+  before?" cross-project. See arc doc §"L3 semantic memory
+  (OpenBrain) integration".
 - New watcher anomaly `tempering-bug-unaddressed` (severity: warn) —
   any `real-bug` open > 14 days with no `linkedFixPlan`
 - **`forge_liveguard_run` integration** (the deferred wire-in

--- a/docs/plans/Phase-TEMPER-ARC.md
+++ b/docs/plans/Phase-TEMPER-ARC.md
@@ -268,6 +268,42 @@ They're called out here so every later phase has a stable target.
 - `tempering-bug-validated-fixed` (TEMPER-06)
 - `tempering-visual-regression-detected` (TEMPER-04)
 
+### L3 semantic memory (OpenBrain) integration
+
+Tempering writes to all three tiers of Plan Forge's memory architecture
+(see [`docs/MEMORY-ARCHITECTURE.md`](../MEMORY-ARCHITECTURE.md)):
+
+| Tier | Surface | Writer |
+|------|---------|--------|
+| **L1** (hub) | `tempering-*` events (above) | every scanner, every MCP tool |
+| **L2** (files) | `.forge/tempering/<runId>.json`, `.forge/bugs/<bugId>.json`, `.forge/tempering/config.json`, `.forge/tempering/perf-history.jsonl`, `.forge/tempering/baselines/` | scanners + registry |
+| **L3** (semantic) | OpenBrain via `captureMemory()` (falls back to `.forge/openbrain-queue.jsonl` when offline) | see capture table below |
+
+**L3 capture sites** — each goes through the existing `captureMemory()`
+helper so OpenBrain outages never block a tempering run:
+
+| Capture site | Phase | Tags | Why L3 |
+|--------------|-------|------|--------|
+| Scan-completed summary (coverage gaps) | TEMPER-01 | `tempering`, `scan`, `<stack>`, `<status>` | "Has this project — or similar projects — had this coverage shape before?" |
+| Run-completed verdict | TEMPER-02 | `tempering`, `run`, `<stack>`, `<verdict>` | Cross-project recall of what scanner mixes produce green/amber/red |
+| Visual quorum decision | TEMPER-04 | `tempering`, `visual-regression`, `<verdict>`, `quorum:<n-of-m>` | Quorum disagreement patterns are valuable across projects (false-positive calibration) |
+| Flake-confirmed (≥ 3 of N runs) | TEMPER-05 | `tempering`, `flake`, `<scanner>`, `<testName>` | "This test has been flaky in other projects too" |
+| Perf regression confirmed (2 consecutive runs) | TEMPER-05 | `tempering`, `perf-regression`, `<endpoint-or-page>` | Cross-project p95 baselines |
+| Mutation score below minimum | TEMPER-05 | `tempering`, `mutation-gap`, `<layer>` | Weak-suite patterns by layer |
+| Bug-registered (real-bug only) | TEMPER-06 | `tempering-bug`, `<category>`, `<severity>`, `confidence-source:<rule\|llm>` | Cross-project bug pattern recall feeds future classifier confidence |
+| Fix-validated (fix → validation pair) | TEMPER-06 | `tempering-fix`, `<bugCategory>`, `<outcome>` | "What fixes have worked for this class of bug before?" |
+
+**Forbidden in L3:**
+
+- Do NOT capture screenshots or binary blobs — L3 stores the verdict
+  and metadata; the evidence stays in L2 under `.forge/bugs/<id>.json`
+- Do NOT capture GitHub issue tokens, PII, or repo-private URLs in
+  tags — `captureMemory()` already scrubs, but scanners must not
+  hand-roll payloads that bypass it
+- Do NOT capture test-infra-only bugs to L3 — only `real-bug`
+  classifications cross the L3 threshold (infra noise would pollute
+  cross-project search)
+
 ### Watcher anomalies introduced
 
 - `tempering-coverage-below-minimum` (TEMPER-01)

--- a/docs/plans/Phase-TEMPER-ARC.md
+++ b/docs/plans/Phase-TEMPER-ARC.md
@@ -130,6 +130,68 @@ depends on a later one to function.
 These are the decisions that, once shipped, cannot be changed cheaply.
 They're called out here so every later phase has a stable target.
 
+### Correlation ID — the thread through the whole loop
+
+Every Tempering record carries a `correlationId` (UUID) that links it
+back to the originating idea all the way through the loop:
+
+```
+Crucible smelt.correlationId
+  └─► plan frontmatter.correlationId (set on hardening-handoff)
+       └─► run summary.correlationId (set by forge_run_plan)
+            └─► slice record.correlationId
+                 └─► tempering run.correlationId
+                      ├─► bug record.correlationId
+                      │    └─► fix plan frontmatter.correlationId
+                      │         └─► bug-validated fix record.correlationId
+                      └─► incident.correlationId (if LiveGuard opens one)
+```
+
+Rules:
+- Every L2 record MUST stamp `correlationId` when one is in context
+- Every L3 `captureMemory()` payload MUST include it as a tag
+  (`corr:<uuid>`) for cross-tier join
+- Every hub event payload MUST include it (additive field, does not
+  break existing consumers)
+- `forge_crucible_submit` mints the ID; everything downstream inherits
+- When a record has no upstream (e.g. `forge_tempering_scan` run
+  standalone, no plan context), it mints its own and stamps it
+
+TEMPER-01 adds the field to scan records + run records. TEMPER-02
+propagates to runs. TEMPER-06 propagates to bugs + fix plans +
+validations. The full thread is first observable end-to-end when
+TEMPER-06 ships.
+
+### Cost dimensions — beyond LLM tokens
+
+Tempering adds large non-LLM cost surfaces. The existing
+`forge_cost_report` gains a `dimension` field so operators can set
+per-dimension budgets without mixing apples and oranges:
+
+| Dimension | Unit | Writer |
+|-----------|------|--------|
+| `llm-quorum` | tokens × model × call | visual analyzer, bug classifier |
+| `visual-analyzer` | calls × pages × slices | TEMPER-04 scanner |
+| `mutation-runtime` | CPU seconds | TEMPER-05 mutation scanner |
+| `load-runtime` | wall seconds × concurrency | TEMPER-05 load scanner |
+| `embed` | embedding tokens | `captureMemory()` → OpenBrain |
+| `llm-arbitration` | tokens | TEMPER-06 classifier LLM layer |
+
+Each dimension supports a `softBudget` (warn via hub event
+`cost-budget-warn`) and `hardBudget` (abort + register infra bug).
+TEMPER-01 ships the schema + warn event wiring; TEMPER-02 through
+TEMPER-06 each populate the dimensions they own.
+
+### Manual chapter 8 "The closed loop in 10 minutes"
+
+TEMPER-06 ships the capstone manual chapter: a single worked example
+walking idea → Crucible smelt → plan hardening → Forge execution →
+Tempering run → real-bug discovery → GitHub issue filing → fix-plan
+generation → execution → validation → GitHub comment → incident
+absence. Uses the correlationId above to show one unbroken chain of
+L1/L2/L3 records. Replaces the current "N chapters per subsystem, no
+story" docs gap.
+
 ### `.forge/tempering/config.json` shape
 
 ```jsonc


### PR DESCRIPTION
## Summary

Adds L3 (OpenBrain semantic memory) integration to the Tempering arc plan docs. Caught in review after PR #51 merged: the 7 arc docs covered L1 (hub events) and L2 (`.forge/` files) but were silent on L3 — breaking the pattern LiveGuard and Crucible follow.

## Changes

**Arc doc** — new section `L3 semantic memory (OpenBrain) integration` with:
- Three-tier summary table
- Capture-site table per phase
- L3 forbidden actions (no blobs, no tokens, no infra-bug noise)

**Per-phase line-items** added to scope contracts:
- TEMPER-01 — scan-completed capture
- TEMPER-02 — run-completed capture
- TEMPER-04 — visual quorum-decision capture (verdicts only, no images)
- TEMPER-05 — flake-confirmed / perf-regression / mutation-gap captures
- TEMPER-06 — bug-registered (real-bug only) + fix-validated captures

## Not changed

- No code. No VERSION bump. No CHANGELOG entry (docs-only arc amendment).
- All captures go through existing `captureMemory()` helper — OpenBrain outages fall through to `.forge/openbrain-queue.jsonl` as usual.

## Follow-up

Execution of TEMPER-01 Slice 01.1 remains unchanged timing-wise; the L3 wire-in is now part of its scope contract.
