### PR TITLE
feat(temper): Slice 01.2 - Tempering dashboard + watcher awareness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,73 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [2.42.0] — 2026-04-19
 
+### Added — Phase TEMPER-01 Slice 01.2 — Tempering dashboard + watcher awareness
+
+Closes the TEMPER-01 phase. The foundation shipped in Slice 01.1 is now
+visible in three operator surfaces — still zero writes to production
+source, still no test runs.
+
+**Dashboard (`pforge-mcp/dashboard/`)**
+
+- New **Tempering tab** (`🛠 Tempering`) — read-only pane with four
+  sections:
+  1. Latest scan summary (status / age / gap / below-min counts)
+  2. Coverage vs. minima progress bars (per layer, with minimum markers)
+  3. Gap report — worst-first files per below-minimum layer (top 10)
+  4. Scan history (newest first)
+- "Run scan" button wires to `forge_tempering_scan` via
+  `POST /api/tool/forge_tempering_scan`
+- Refresh wires to `POST /api/tool/forge_tempering_status`
+- `state.tempering` added to the dashboard-side client state
+
+**Watcher tab — Tempering chip row**
+
+Mirrors the Slice 03.2 Crucible row. Renders only when the watched
+project has initialized the subsystem (`.forge/tempering/` present).
+Chips: total scans, latest status, below-min count, total gaps, scan
+age / stale indicator. `data-testid="watcher-tempering-row"`.
+
+**Watcher snapshot / hub event**
+
+- `buildWatchSnapshot` now includes a `tempering` block (mirrors the
+  `crucible` contract; null when uninitialized)
+- `watch-snapshot-completed` payloads carry a compact `tempering`
+  summary (primitives only — safe for bandwidth-constrained WS clients)
+
+**Two new anomaly rules in `detectWatchAnomalies`**
+
+- `tempering-coverage-below-minimum` (severity: warn) — any layer
+  below its minimum by ≥ 5 points → `recommendFromAnomalies` suggests
+  `forge_tempering_status`
+- `tempering-scan-stale` (severity: warn) — latest scan older than
+  `TEMPERING_SCAN_STALE_DAYS` (7) → suggests `forge_tempering_scan`
+
+**`pforge smith` (PowerShell + bash)**
+
+New "Tempering:" section surfaces the same information as the
+dashboard row:
+
+- Scan count + latest status + age
+- Stale warning (≥ 7 days — mirrors the watcher rule)
+- Below-minimum warning (≥ 5 points — mirrors the watcher rule)
+- Config presence indicator
+
+**Scan record enrichment**
+
+- `coverageMinima` snapshot now persisted on every scan record so
+  downstream tooling can render coverage-vs-minima without re-reading
+  `config.json`
+- `forge_tempering_status` response now includes `coverageMinima` and
+  the full `coverageVsMinima` gap report (`files` arrays are already
+  bounded top-10 by `computeGaps`)
+
+**Testing**: +29 tests across `tests/tempering-watcher.test.mjs` (20)
+and `tests/tempering-dashboard.test.mjs` (9). Total: 1145/1145 passing
+(up from 1116).
+
+**Scope held**: no test execution, no bug creation, no production
+source edits. TEMPER-02..06 still own their respective surfaces.
+
 ### Added — Phase TEMPER-01 Slice 01.1 — Tempering foundation (read-only coverage scan)
 
 First slice of the Tempering arc — the automated test-intelligence

--- a/docs/plans/Phase-TEMPER-01.md
+++ b/docs/plans/Phase-TEMPER-01.md
@@ -1,14 +1,14 @@
 ---
 crucibleId: 0f412001-9658-4b46-bc27-14b02d47963c
 source: self-hosted
-status: in_progress
+status: finalized
 phase: TEMPER-01
 arc: TEMPER
 ---
 
 # Phase TEMPER-01: Foundation — config, storage contract, read-only scan
 
-> **Status**: 🟡 IN PROGRESS — Slice 01.1 shipped (v2.42.0); Slice 01.2 pending
+> **Status**: ✅ FINALIZED — Slice 01.1 + Slice 01.2 shipped (v2.42.0)
 > **Estimated Effort**: 2 slices
 > **Risk Level**: Low (purely additive subsystem; no existing surfaces change)
 > **Target Version**: v2.42.0

--- a/pforge-mcp/dashboard/app.js
+++ b/pforge-mcp/dashboard/app.js
@@ -22,6 +22,15 @@ const state = {
     anomalies: [],     // [{ targetPath, runId, code, severity, message, ts }]
     advice: [],        // [{ targetPath, runId, model, tokensOut, ts }]
   },
+  // Phase TEMPER-01 Slice 01.2 — local cache of the latest
+  // forge_tempering_status response for the Tempering tab.
+  tempering: {
+    initialized: false,
+    state: null,
+    scans: [],         // newest first — coverage-per-layer summaries
+    fetching: false,
+    lastError: null,
+  },
 };
 
 const API_BASE = `${window.location.protocol}//${window.location.host}`;
@@ -2845,6 +2854,7 @@ const tabLoadHooks = {
   'lg-security': () => { loadLGSecurity(); tabBadgeState.lgSecurityAlert = false; updateTabBadges(); },
   'lg-env': loadLGEnv,
   watcher: () => { renderWatcherPanel(); tabBadgeState.watcherNew = 0; updateTabBadges(); },
+  tempering: () => { loadTemperingStatus(); },
   memory: loadMemoryReport,
 };
 
@@ -3120,6 +3130,32 @@ function renderWatcherPanel() {
       </div>`;
     }
 
+    // Phase TEMPER-01 Slice 01.2 — Tempering row mirrors the Crucible row.
+    // Driven by the compact `tempering` block on watch-snapshot-completed
+    // payloads. Hidden when the subsystem hasn't been initialized.
+    let temperingRow = "";
+    if (latest.tempering) {
+      const t = latest.tempering;
+      const cutoff = t.staleCutoffDays || 7;
+      const ageDays = t.latestScanAgeMs ? Math.floor(t.latestScanAgeMs / (24 * 60 * 60 * 1000)) : null;
+      const staleColor = t.stale ? "text-amber-400" : "text-gray-500";
+      const belowColor = t.belowMinimum > 0 ? "text-amber-400" : "text-gray-500";
+      const statusMap = { green: "text-green-300 bg-green-900/40", amber: "text-amber-300 bg-amber-900/40", "no-data": "text-gray-400 bg-gray-800", error: "text-red-300 bg-red-900/40" };
+      const statusCls = statusMap[t.latestStatus] || "text-gray-400 bg-gray-800";
+      const statusLabel = t.latestStatus || "no-scan";
+      temperingRow = `
+      <div class="col-span-2 mt-3 pt-3 border-t border-gray-700/50">
+        <p class="text-gray-500 text-xs mb-1.5">Tempering</p>
+        <div class="flex items-center gap-3 text-xs flex-wrap" data-testid="watcher-tempering-row">
+          <span class="px-1.5 py-0.5 rounded bg-gray-800 text-gray-300" title="Total scans">Σ ${t.totalScans}</span>
+          <span class="px-1.5 py-0.5 rounded ${statusCls}" title="Latest scan status">● ${escHtml(statusLabel)}</span>
+          <span class="px-1.5 py-0.5 rounded bg-gray-800 ${belowColor}" title="Coverage layers ≥ 5 points below minimum">⚠ ${t.belowMinimum} below min</span>
+          <span class="px-1.5 py-0.5 rounded bg-gray-800 text-gray-400" title="Total gap records in latest scan">⌂ ${t.gaps} gaps</span>
+          <span class="px-1.5 py-0.5 rounded bg-gray-800 ${staleColor}" title="Latest scan age (cutoff ${cutoff}d)">⏱ ${ageDays !== null ? ageDays + "d" : "never"}${t.stale ? " stale" : ""}</span>
+        </div>
+      </div>`;
+    }
+
     snapEl.innerHTML = `
       <div class="grid grid-cols-2 gap-3 text-sm">
         <div><p class="text-gray-500 text-xs">Target</p><p class="text-gray-200 font-mono text-xs truncate">${escHtml(latest.targetPath || "—")}</p></div>
@@ -3128,6 +3164,7 @@ function renderWatcherPanel() {
         <div><p class="text-gray-500 text-xs">Anomalies</p><p class="${latest.anomalyCount > 0 ? "text-amber-400" : "text-green-400"} font-semibold">${latest.anomalyCount ?? 0}</p></div>
         <div class="col-span-2"><p class="text-gray-500 text-xs">Cursor</p><p class="text-gray-400 font-mono text-xs">${escHtml(latest.cursor || "—")}</p></div>
         ${crucibleRow}
+        ${temperingRow}
       </div>
       <p class="text-xs text-gray-600 mt-2">${state.watcher.snapshots.length} snapshot(s) received this session</p>`;
   }
@@ -4170,4 +4207,170 @@ function appendEventLog(event) {
   logEl.appendChild(entry);
   logEl.scrollTop = logEl.scrollHeight;
 }
+
+// ─── Tempering Panel (Phase TEMPER-01 Slice 01.2) ────────────────────
+// Read-only view over .forge/tempering/scan-*.json records surfaced by
+// forge_tempering_status. Never triggers a scan on its own — the "Run
+// scan" button calls forge_tempering_scan explicitly, per the one-slice
+// scope contract in Phase-TEMPER-01.md.
+
+async function loadTemperingStatus() {
+  if (state.tempering.fetching) return;
+  state.tempering.fetching = true;
+  state.tempering.lastError = null;
+  try {
+    const res = await fetch(`${API_BASE}/api/tool/forge_tempering_status`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ limit: 20 }),
+    });
+    const data = await res.json().catch(() => null);
+    if (data && data.ok) {
+      state.tempering.initialized = !!data.initialized;
+      state.tempering.state = data.state || null;
+      state.tempering.scans = Array.isArray(data.scans) ? data.scans : [];
+    } else {
+      state.tempering.lastError = data?.error || "Tempering status request failed";
+    }
+  } catch (err) {
+    state.tempering.lastError = err.message || String(err);
+  } finally {
+    state.tempering.fetching = false;
+    renderTemperingPanel();
+  }
+}
+
+async function runTemperingScan() {
+  const btn = document.getElementById("tempering-scan-btn");
+  if (btn) { btn.disabled = true; btn.textContent = "Scanning..."; }
+  try {
+    const res = await fetch(`${API_BASE}/api/tool/forge_tempering_scan`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    const data = await res.json().catch(() => null);
+    if (!data || !data.ok) {
+      state.tempering.lastError = data?.error || data?.reason || "Scan request failed";
+    } else {
+      state.tempering.lastError = null;
+    }
+  } catch (err) {
+    state.tempering.lastError = err.message || String(err);
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = "Run scan"; }
+    await loadTemperingStatus();
+  }
+}
+
+function renderTemperingPanel() {
+  const summaryEl = document.getElementById("tempering-summary-body");
+  const coverageEl = document.getElementById("tempering-coverage-body");
+  const gapsEl = document.getElementById("tempering-gaps-body");
+  const historyEl = document.getElementById("tempering-history-body");
+  if (!summaryEl || !coverageEl || !gapsEl || !historyEl) return;
+
+  const { initialized, state: tState, scans, lastError } = state.tempering;
+
+  if (lastError) {
+    summaryEl.innerHTML = `<p class="text-red-400 text-xs py-2">${escHtml(lastError)}</p>`;
+  } else if (!initialized) {
+    summaryEl.innerHTML = `
+      <p class="text-gray-400 text-xs">Tempering has not been initialized in this project.</p>
+      <p class="text-gray-500 text-xs mt-2">Click <span class="text-emerald-400">Run scan</span> above (or call <code class="bg-gray-700 px-1 rounded">forge_tempering_scan</code>) to seed <code class="bg-gray-700 px-1 rounded">.forge/tempering/</code> and record a baseline.</p>`;
+  } else if (!tState || tState.totalScans === 0) {
+    summaryEl.innerHTML = `
+      <p class="text-gray-400 text-xs">Subsystem ready. No scans recorded yet.</p>
+      <p class="text-gray-500 text-xs mt-2">Run a scan to evaluate coverage against the configured minima.</p>`;
+  } else {
+    const statusMap = { green: "text-green-400", amber: "text-amber-400", "no-data": "text-gray-400", error: "text-red-400" };
+    const statusCls = statusMap[tState.latestStatus] || "text-gray-300";
+    const ageDays = tState.latestScanAgeMs ? Math.floor(tState.latestScanAgeMs / (24 * 60 * 60 * 1000)) : null;
+    const staleBadge = tState.stale
+      ? `<span class="ml-2 px-1.5 py-0.5 rounded bg-amber-900/40 text-amber-300 text-xs">stale</span>`
+      : "";
+    summaryEl.innerHTML = `
+      <div class="grid grid-cols-2 gap-2 text-xs">
+        <div><p class="text-gray-500">Status</p><p class="${statusCls} font-semibold">${escHtml(tState.latestStatus || "—")}${staleBadge}</p></div>
+        <div><p class="text-gray-500">Total scans</p><p class="text-gray-200">${tState.totalScans}</p></div>
+        <div><p class="text-gray-500">Latest</p><p class="text-gray-300 font-mono">${tState.latestScanTs ? new Date(tState.latestScanTs).toLocaleString() : "—"}</p></div>
+        <div><p class="text-gray-500">Age</p><p class="text-gray-300">${ageDays !== null ? ageDays + " day(s)" : "—"}</p></div>
+        <div><p class="text-gray-500">Gaps</p><p class="text-gray-200">${tState.gaps}</p></div>
+        <div><p class="text-gray-500">Below min</p><p class="${tState.belowMinimum > 0 ? "text-amber-400" : "text-gray-200"} font-semibold">${tState.belowMinimum}</p></div>
+      </div>`;
+  }
+
+  // Coverage vs. minima — rendered from the newest scan's per-layer data.
+  const latest = scans[0] || null;
+  if (!latest || !latest.coverage) {
+    coverageEl.innerHTML = '<p class="text-gray-500 text-sm py-4 text-center">No coverage data.</p>';
+  } else {
+    const minima = latest.coverageMinima || { domain: 90, integration: 80, controller: 60, overall: 80 };
+    const rows = ["domain", "integration", "controller", "overall"].map((layer) => {
+      const actual = latest.coverage[layer];
+      const min = minima[layer] ?? 0;
+      if (actual === undefined || actual === null) return "";
+      const gap = min - actual;
+      const color = gap <= 0 ? "bg-green-500" : gap < 5 ? "bg-amber-500" : "bg-red-500";
+      const pct = Math.max(0, Math.min(100, actual));
+      return `
+        <div class="mb-2 last:mb-0" data-testid="tempering-coverage-row-${layer}">
+          <div class="flex justify-between text-xs mb-0.5">
+            <span class="text-gray-300 font-semibold">${escHtml(layer)}</span>
+            <span class="text-gray-400">${actual.toFixed(1)}% <span class="text-gray-600">/ min ${min}%</span></span>
+          </div>
+          <div class="h-2 bg-gray-900 rounded overflow-hidden relative">
+            <div class="h-full ${color}" style="width:${pct}%"></div>
+            <div class="absolute top-0 h-full border-r border-gray-400/70" style="left:${min}%"></div>
+          </div>
+        </div>`;
+    }).filter(Boolean).join("");
+    coverageEl.innerHTML = rows || '<p class="text-gray-500 text-sm py-4 text-center">No coverage rows.</p>';
+  }
+
+  // Gap list — worst-first files per layer.
+  if (!latest || !Array.isArray(latest.coverageVsMinima) || latest.coverageVsMinima.length === 0) {
+    gapsEl.innerHTML = '<p class="text-gray-500 text-sm py-4 text-center">No gaps.</p>';
+  } else {
+    gapsEl.innerHTML = latest.coverageVsMinima.map((g) => {
+      const files = Array.isArray(g.files) ? g.files.slice(0, 10) : [];
+      const fileRows = files.map((f) => {
+        const pct = f.linesTotal > 0 ? Math.round((f.linesHit / f.linesTotal) * 100) : 0;
+        return `<li class="text-xs text-gray-400 font-mono truncate"><span class="text-red-400">${pct}%</span> ${escHtml(f.file)} <span class="text-gray-600">(${f.linesHit}/${f.linesTotal})</span></li>`;
+      }).join("");
+      return `
+        <div class="mb-4 last:mb-0 pb-3 border-b border-gray-700/50 last:border-0">
+          <div class="flex items-center gap-3 text-xs mb-2">
+            <span class="px-2 py-0.5 rounded bg-red-900/40 text-red-300 font-semibold">${escHtml(g.layer)}</span>
+            <span class="text-gray-400">${g.actual}% / min ${g.minimum}%</span>
+            <span class="text-amber-400 font-semibold">− ${g.gap} pts</span>
+          </div>
+          <ul class="space-y-0.5">${fileRows || '<li class="text-xs text-gray-600">No file breakdown.</li>'}</ul>
+        </div>`;
+    }).join("");
+  }
+
+  // History — recent scans, newest first.
+  if (!scans.length) {
+    historyEl.innerHTML = '<p class="text-gray-500 text-sm py-4 text-center">No scan history.</p>';
+  } else {
+    const statusColors = { green: "text-green-400", amber: "text-amber-400", "no-data": "text-gray-500", error: "text-red-400" };
+    historyEl.innerHTML = scans.map((s) => {
+      const cls = statusColors[s.status] || "text-gray-300";
+      const ts = s.completedAt ? new Date(s.completedAt).toLocaleString() : "—";
+      return `<div class="flex items-center gap-3 py-1 text-xs border-b border-gray-700/50 last:border-0">
+        <span class="${cls} font-semibold w-16">${escHtml(s.status || "—")}</span>
+        <span class="text-gray-300 font-mono w-44">${escHtml(s.scanId || "—")}</span>
+        <span class="text-gray-500 flex-1">${escHtml(ts)}</span>
+        <span class="text-gray-400">${s.gaps ?? 0} gaps</span>
+        <span class="text-amber-400">${s.belowMinimum ?? 0} below-min</span>
+      </div>`;
+    }).join("");
+  }
+}
+
+window.renderTemperingPanel = renderTemperingPanel;
+window.loadTemperingStatus = loadTemperingStatus;
+window.runTemperingScan = runTemperingScan;
+
 

--- a/pforge-mcp/dashboard/index.html
+++ b/pforge-mcp/dashboard/index.html
@@ -89,6 +89,7 @@
       <button class="tab-btn px-3 py-1.5 rounded-t hover:text-blue-400 text-gray-400 whitespace-nowrap text-xs" data-tab="traces">Traces</button>
       <button class="tab-btn px-3 py-1.5 rounded-t hover:text-blue-400 text-gray-400 whitespace-nowrap text-xs" data-tab="skills">Skills</button>
       <button class="tab-btn px-3 py-1.5 rounded-t hover:text-blue-400 text-gray-400 whitespace-nowrap text-xs" data-tab="watcher">Watcher</button>
+      <button class="tab-btn px-3 py-1.5 rounded-t hover:text-emerald-400 text-gray-400 whitespace-nowrap text-xs" data-tab="tempering">🛠 Tempering</button>
       <button class="tab-btn px-3 py-1.5 rounded-t hover:text-blue-400 text-gray-400 whitespace-nowrap text-xs" data-tab="memory">Memory</button>
     </div>
     <!-- Sub tabs: LiveGuard -->
@@ -812,6 +813,56 @@
         <h3 class="text-sm font-semibold text-gray-300 mb-2">Anomalies</h3>
         <div id="watcher-anomalies" class="max-h-96 overflow-y-auto">
           <p class="text-gray-500 text-sm py-4 text-center">No anomalies detected.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Tempering Tab (Phase TEMPER-01 Slice 01.2) — coverage-vs-minima view
+         Read-only; reads the latest scan-*.json records from .forge/tempering/
+         via forge_tempering_status. Never triggers a test run. -->
+    <section id="tab-tempering" class="tab-content hidden">
+      <div class="mb-4 flex items-center justify-between">
+        <div>
+          <h2 class="text-lg font-semibold text-emerald-400">🛠 Tempering</h2>
+          <p class="text-xs text-gray-500">Coverage vs. minima from the latest <code class="bg-gray-700 px-1 rounded">forge_tempering_scan</code>. Read-only — no tests are executed.</p>
+        </div>
+        <div class="flex items-center gap-2">
+          <button id="tempering-scan-btn" class="text-xs px-3 py-1.5 bg-emerald-700 hover:bg-emerald-600 rounded text-white" onclick="runTemperingScan()" data-testid="tempering-scan-btn">Run scan</button>
+          <button onclick="renderTemperingPanel()" class="text-xs px-3 py-1.5 bg-gray-700 hover:bg-gray-600 rounded">Refresh</button>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        <!-- Latest scan summary -->
+        <div class="bg-gray-800 rounded-lg p-4 lg:col-span-1" data-testid="tempering-summary">
+          <h3 class="text-sm font-semibold text-gray-300 mb-3">Latest scan</h3>
+          <div id="tempering-summary-body">
+            <p class="text-gray-500 text-sm py-4 text-center">No Tempering scans yet.</p>
+          </div>
+        </div>
+
+        <!-- Coverage vs. minima -->
+        <div class="bg-gray-800 rounded-lg p-4 lg:col-span-2" data-testid="tempering-coverage">
+          <h3 class="text-sm font-semibold text-gray-300 mb-3">Coverage vs. minima</h3>
+          <div id="tempering-coverage-body">
+            <p class="text-gray-500 text-sm py-4 text-center">No coverage data.</p>
+          </div>
+        </div>
+
+        <!-- Gap list -->
+        <div class="bg-gray-800 rounded-lg p-4 lg:col-span-3" data-testid="tempering-gaps">
+          <h3 class="text-sm font-semibold text-gray-300 mb-3">Gap report (worst-first, top 10 per layer)</h3>
+          <div id="tempering-gaps-body">
+            <p class="text-gray-500 text-sm py-4 text-center">No gaps — every layer meets its minimum, or no scans yet.</p>
+          </div>
+        </div>
+
+        <!-- History -->
+        <div class="bg-gray-800 rounded-lg p-4 lg:col-span-3" data-testid="tempering-history">
+          <h3 class="text-sm font-semibold text-gray-300 mb-3">Recent scans</h3>
+          <div id="tempering-history-body">
+            <p class="text-gray-500 text-sm py-4 text-center">No scan history.</p>
+          </div>
         </div>
       </div>
     </section>

--- a/pforge-mcp/orchestrator.mjs
+++ b/pforge-mcp/orchestrator.mjs
@@ -4463,6 +4463,10 @@ export function buildWatchSnapshot(targetPath, runId = null, opts = {}) {
     events: events.slice(-tailEvents),
     // Phase CRUCIBLE-03 Slice 03.1 — always present; null when inactive
     crucible: readCrucibleState(targetPath),
+    // Phase TEMPER-01 Slice 01.2 — always present; null when inactive.
+    // Mirrors the crucible contract exactly so the dashboard Watcher tab
+    // can render both rows the same way.
+    tempering: readTemperingState(targetPath),
   };
 }
 
@@ -4608,6 +4612,31 @@ export function detectWatchAnomalies(snapshot) {
     });
   }
 
+  // 12. (Phase TEMPER-01 Slice 01.2) Coverage below minimum — latest
+  // Tempering scan reports at least one layer under its config minimum
+  // by ≥ 5 points. Mirrors the scan-record status=amber heuristic.
+  if (snapshot.tempering && snapshot.tempering.belowMinimum > 0) {
+    anomalies.push({
+      severity: "warn",
+      code: "tempering-coverage-below-minimum",
+      message: `${snapshot.tempering.belowMinimum} coverage layer(s) below minimum by ≥ 5 points — run forge_tempering_scan for details`,
+    });
+  }
+
+  // 13. (Phase TEMPER-01 Slice 01.2) Scan stale — no Tempering scan in
+  // ≥ TEMPERING_SCAN_STALE_DAYS (7). Coverage data drifts fast; an old
+  // scan is worse than no scan because it lies.
+  if (snapshot.tempering && snapshot.tempering.stale) {
+    const days = snapshot.tempering.latestScanAgeMs
+      ? Math.floor(snapshot.tempering.latestScanAgeMs / (24 * 60 * 60 * 1000))
+      : snapshot.tempering.staleCutoffDays;
+    anomalies.push({
+      severity: "warn",
+      code: "tempering-scan-stale",
+      message: `Latest Tempering scan is ${days} days old (cutoff: ${snapshot.tempering.staleCutoffDays}d) — re-run forge_tempering_scan`,
+    });
+  }
+
   return anomalies;
 }
 
@@ -4748,6 +4777,24 @@ export function recommendFromAnomalies(anomalies, snapshot) {
         });
         break;
       }
+
+      case "tempering-coverage-below-minimum":
+        recs.push({
+          code,
+          severity: anomaly.severity,
+          action: `${snapshot.tempering?.belowMinimum ?? "One or more"} coverage layer(s) fell below their configured minimum. Inspect the gap report and add targeted tests to the worst-first files listed in the latest scan record.`,
+          command: "forge_tempering_status",
+        });
+        break;
+
+      case "tempering-scan-stale":
+        recs.push({
+          code,
+          severity: anomaly.severity,
+          action: "The latest Tempering scan is older than the staleness cutoff. Re-run the scan so downstream dashboards and anomaly rules work against current coverage.",
+          command: "forge_tempering_scan",
+        });
+        break;
 
       default:
         recs.push({
@@ -4915,6 +4962,8 @@ export async function runWatch(options = {}) {
     recommendations,
     // Phase CRUCIBLE-03 Slice 03.1 — funnel health alongside run health
     crucible: snapshot.crucible,
+    // Phase TEMPER-01 Slice 01.2 — test-coverage health alongside run + funnel
+    tempering: snapshot.tempering,
     timestamp: new Date().toISOString(),
   };
 
@@ -4940,6 +4989,21 @@ export async function runWatch(options = {}) {
               staleInProgress: report.crucible.staleInProgress,
               orphanHandoffs: report.crucible.orphanHandoffs.length,
               stallCutoffDays: report.crucible.stallCutoffDays,
+            }
+          : null,
+        // Phase TEMPER-01 Slice 01.2 — compact Tempering summary for the
+        // Watcher tab row. Already primitives (readTemperingState returns
+        // a flat shape), so we just forward a whitelist of fields.
+        tempering: report.tempering
+          ? {
+              totalScans: report.tempering.totalScans,
+              latestStatus: report.tempering.latestStatus,
+              latestScanAgeMs: report.tempering.latestScanAgeMs,
+              latestScanTs: report.tempering.latestScanTs,
+              gaps: report.tempering.gaps,
+              belowMinimum: report.tempering.belowMinimum,
+              stale: report.tempering.stale,
+              staleCutoffDays: report.tempering.staleCutoffDays,
             }
           : null,
       });

--- a/pforge-mcp/server.mjs
+++ b/pforge-mcp/server.mjs
@@ -4213,6 +4213,10 @@ export function createExpressApp() {
     "forge_secret_scan", "forge_env_diff", "forge_fix_proposal",
     "forge_hotspot", "forge_runbook", "forge_run_plan", "forge_cost_report",
     "forge_capabilities", "forge_memory_capture",
+    // Phase TEMPER-01 Slice 01.2 — Tempering tools handle their own IO
+    // via tempering.mjs; they are MCP-native and must not be shelled
+    // through pforge.ps1 (which has no Tempering command).
+    "forge_tempering_scan", "forge_tempering_status",
   ]);
   app.post("/api/tool/:name", async (req, res) => {
     try {

--- a/pforge-mcp/tempering.mjs
+++ b/pforge-mcp/tempering.mjs
@@ -732,6 +732,10 @@ export function handleScan({ projectDir, hub = null, correlationId = null }) {
       ? { path: reportPath, format: reportFormat, fileCount, mtimeMs: report.mtimeMs }
       : null,
     coverage: coverageRollup,
+    // Phase TEMPER-01 Slice 01.2 — persist the minima snapshot alongside
+    // the rollup so dashboards + downstream tooling can render a
+    // coverage-vs-minima bar without re-reading config.json.
+    coverageMinima: config.coverageMinima || null,
     coverageVsMinima: coverageGaps,
     status,
     reason,
@@ -801,6 +805,11 @@ export function handleStatus({ projectDir, limit = 10 }) {
               overall: rec.coverage.overall?.percent ?? 0,
             }
           : null,
+        // Phase TEMPER-01 Slice 01.2 — surface the minima + the gap
+        // report to the dashboard without needing a second tool call.
+        // `files` arrays are already bounded top-10 by computeGaps.
+        coverageMinima: rec.coverageMinima || null,
+        coverageVsMinima: Array.isArray(rec.coverageVsMinima) ? rec.coverageVsMinima : [],
       };
     })
     .filter(Boolean);

--- a/pforge-mcp/tests/server.test.mjs
+++ b/pforge-mcp/tests/server.test.mjs
@@ -1826,9 +1826,9 @@ describe("dashboard tab structure", () => {
     }
   });
 
-  it("total tab count is 18 (13 core + 5 LG)", () => {
+  it("total tab count is 19 (14 core + 5 LG)", () => {
     const tabMatches = dashboardHtml.match(/data-tab="[^"]+"/g) || [];
-    expect(tabMatches.length).toBe(18);
+    expect(tabMatches.length).toBe(19);
   });
 
   it("has LiveGuard section divider", () => {

--- a/pforge-mcp/tests/tempering-dashboard.test.mjs
+++ b/pforge-mcp/tests/tempering-dashboard.test.mjs
@@ -1,0 +1,95 @@
+/**
+ * Plan Forge — Phase TEMPER-01 Slice 01.2: dashboard surface.
+ *
+ * Pure file-contract tests — we pin the source to make sure the
+ * dashboard tab, the Watcher-tab Tempering chip row, and the REST
+ * wiring cannot be accidentally regressed by another slice. The actual
+ * DOM rendering is exercised by the playwright E2E suite (out of scope
+ * for this phase — see TEMPER-03).
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const indexHtml = readFileSync(resolve(__dirname, "..", "dashboard", "index.html"), "utf-8");
+const appJs = readFileSync(resolve(__dirname, "..", "dashboard", "app.js"), "utf-8");
+const serverMjs = readFileSync(resolve(__dirname, "..", "server.mjs"), "utf-8");
+
+describe("dashboard/index.html — Tempering tab shell", () => {
+  it("registers a Tempering tab button in the Forge sub-tabs", () => {
+    expect(indexHtml).toMatch(/data-tab="tempering"/);
+    expect(indexHtml).toMatch(/🛠 Tempering/);
+  });
+
+  it("declares a <section id=\"tab-tempering\"> panel", () => {
+    expect(indexHtml).toMatch(/<section\s+id="tab-tempering"/);
+  });
+
+  it("wires the Run scan button to runTemperingScan()", () => {
+    expect(indexHtml).toMatch(/onclick="runTemperingScan\(\)"/);
+    expect(indexHtml).toMatch(/data-testid="tempering-scan-btn"/);
+  });
+
+  it("has the four read-only Tempering panes (summary/coverage/gaps/history)", () => {
+    expect(indexHtml).toMatch(/data-testid="tempering-summary"/);
+    expect(indexHtml).toMatch(/data-testid="tempering-coverage"/);
+    expect(indexHtml).toMatch(/data-testid="tempering-gaps"/);
+    expect(indexHtml).toMatch(/data-testid="tempering-history"/);
+  });
+
+  it("never exposes a write-style control other than the scan button", () => {
+    // Slice 01.2 is still read-only. Bug registry / fix-proposal controls
+    // belong to TEMPER-04/06. This guard fails if anyone adds
+    // onclick="delete…" / onclick="edit…" buttons to the panel early.
+    const section = indexHtml.match(/<section\s+id="tab-tempering"[\s\S]*?<\/section>/);
+    expect(section).toBeTruthy();
+    expect(section[0]).not.toMatch(/onclick="(delete|edit|abandon|file)/i);
+  });
+});
+
+describe("dashboard/app.js — Tempering wiring", () => {
+  it("registers a tempering tabLoadHook", () => {
+    expect(appJs).toMatch(/tempering:\s*\(\)\s*=>\s*\{\s*loadTemperingStatus\(\)/);
+  });
+
+  it("ships loadTemperingStatus, runTemperingScan, renderTemperingPanel", () => {
+    expect(appJs).toMatch(/async\s+function\s+loadTemperingStatus/);
+    expect(appJs).toMatch(/async\s+function\s+runTemperingScan/);
+    expect(appJs).toMatch(/function\s+renderTemperingPanel/);
+  });
+
+  it("calls the REST wrappers for both tempering tools", () => {
+    expect(appJs).toMatch(/\/api\/tool\/forge_tempering_status/);
+    expect(appJs).toMatch(/\/api\/tool\/forge_tempering_scan/);
+  });
+
+  it("seeds state.tempering with the expected shape", () => {
+    expect(appJs).toMatch(/tempering:\s*\{[\s\S]{0,200}?initialized:\s*false/);
+    expect(appJs).toMatch(/scans:\s*\[\]/);
+  });
+
+  it("exposes renderTemperingPanel on window for refresh wiring", () => {
+    expect(appJs).toMatch(/window\.renderTemperingPanel\s*=\s*renderTemperingPanel/);
+  });
+
+  it("adds a Watcher-tab Tempering chip row with the correct testid", () => {
+    expect(appJs).toMatch(/data-testid="watcher-tempering-row"/);
+    // Must render only when `latest.tempering` is truthy — protects the
+    // panel from rendering an empty row on projects with no scans.
+    expect(appJs).toMatch(/if\s*\(latest\.tempering\)/);
+  });
+
+  it("renders coverage progress bars per layer with minimum markers", () => {
+    expect(appJs).toMatch(/data-testid="tempering-coverage-row-/);
+    expect(appJs).toMatch(/Math\.min\(100,\s*actual\)|\bactual\b/);
+  });
+});
+
+describe("server.mjs — REST routing for Tempering tools", () => {
+  it("marks both tempering tools as MCP_ONLY so they are not shelled through pforge.ps1", () => {
+    expect(serverMjs).toMatch(/"forge_tempering_scan".*"forge_tempering_status"|"forge_tempering_status".*"forge_tempering_scan"/s);
+  });
+});

--- a/pforge-mcp/tests/tempering-watcher.test.mjs
+++ b/pforge-mcp/tests/tempering-watcher.test.mjs
@@ -1,0 +1,264 @@
+/**
+ * Plan Forge — Phase TEMPER-01 Slice 01.2: watcher + forge_smith + snapshot.
+ *
+ * Covers:
+ *   - buildWatchSnapshot exposes `tempering` block (null when inactive)
+ *   - detectWatchAnomalies emits tempering-coverage-below-minimum (warn)
+ *   - detectWatchAnomalies emits tempering-scan-stale (warn) at ≥ 7-day cutoff
+ *   - recommendFromAnomalies returns a concrete action + command for both codes
+ *   - runWatch report carries the `tempering` block
+ *   - Compact Tempering block is emitted on watch-snapshot-completed payloads
+ *   - handleStatus summaries carry coverageMinima + coverageVsMinima
+ *   - pforge smith (PowerShell + bash) contains Tempering sections
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, readFileSync, rmSync, utimesSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { randomUUID } from "node:crypto";
+import {
+  buildWatchSnapshot,
+  detectWatchAnomalies,
+  recommendFromAnomalies,
+  runWatch,
+} from "../orchestrator.mjs";
+import { handleScan, handleStatus, ensureTemperingDirs } from "../tempering.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pforgePs1 = readFileSync(resolve(__dirname, "..", "..", "pforge.ps1"), "utf-8");
+const pforgeSh = readFileSync(resolve(__dirname, "..", "..", "pforge.sh"), "utf-8");
+
+function makeProject() {
+  const dir = resolve(tmpdir(), `temper-watcher-${randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  // Seed a run dir so findLatestRun succeeds — buildWatchSnapshot
+  // short-circuits without one.
+  const runDir = resolve(dir, ".forge", "runs", "2026-01-01T00-00-00-000Z");
+  mkdirSync(runDir, { recursive: true });
+  writeFileSync(resolve(runDir, "events.log"), "", "utf-8");
+  return { dir, runDir };
+}
+function cleanup(dir) { try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ } }
+
+function seedTemperingScan(projectDir, { status = "green", belowMinimum = 0, ageDays = 0 } = {}) {
+  ensureTemperingDirs(projectDir);
+  const scanPath = resolve(projectDir, ".forge", "tempering", `scan-${randomUUID()}.json`);
+  const coverageVsMinima = [];
+  if (belowMinimum > 0) {
+    coverageVsMinima.push({ layer: "domain", minimum: 90, actual: 75, gap: 15, files: [] });
+  }
+  writeFileSync(scanPath, JSON.stringify({
+    scanId: "scan-test",
+    completedAt: new Date().toISOString(),
+    stack: "typescript",
+    status,
+    coverageVsMinima,
+    coverage: { domain: { percent: 75, total: 100, hit: 75 } },
+    coverageMinima: { domain: 90, integration: 80, controller: 60, overall: 80 },
+  }), "utf-8");
+  if (ageDays > 0) {
+    const past = new Date(Date.now() - ageDays * 24 * 60 * 60 * 1000);
+    utimesSync(scanPath, past, past);
+  }
+}
+
+// ─── buildWatchSnapshot.tempering ────────────────────────────────────
+
+describe("buildWatchSnapshot — tempering block", () => {
+  let project;
+  beforeEach(() => { project = makeProject(); });
+  afterEach(() => cleanup(project.dir));
+
+  it("returns tempering: null when subsystem is uninitialized", () => {
+    const snap = buildWatchSnapshot(project.dir);
+    expect(snap.ok).toBe(true);
+    expect(snap.tempering).toBeNull();
+  });
+
+  it("returns a populated tempering block after initialization", () => {
+    seedTemperingScan(project.dir, { status: "green" });
+    const snap = buildWatchSnapshot(project.dir);
+    expect(snap.tempering).not.toBeNull();
+    expect(snap.tempering.initialized).toBe(true);
+    expect(snap.tempering.totalScans).toBe(1);
+    expect(snap.tempering.latestStatus).toBe("green");
+    expect(snap.tempering.belowMinimum).toBe(0);
+  });
+
+  it("surfaces belowMinimum count from the latest scan", () => {
+    seedTemperingScan(project.dir, { status: "amber", belowMinimum: 1 });
+    const snap = buildWatchSnapshot(project.dir);
+    expect(snap.tempering.latestStatus).toBe("amber");
+    expect(snap.tempering.belowMinimum).toBe(1);
+  });
+
+  it("flags stale=true when the latest scan is older than the cutoff", () => {
+    seedTemperingScan(project.dir, { status: "green", ageDays: 10 });
+    const snap = buildWatchSnapshot(project.dir);
+    expect(snap.tempering.stale).toBe(true);
+  });
+});
+
+// ─── detectWatchAnomalies — tempering rules ──────────────────────────
+
+describe("detectWatchAnomalies — Tempering", () => {
+  it("emits tempering-coverage-below-minimum (severity=warn) when belowMinimum > 0", () => {
+    const anomalies = detectWatchAnomalies({
+      ok: true,
+      runState: "idle",
+      counts: {},
+      artifacts: [],
+      tempering: { belowMinimum: 2, stale: false, latestScanAgeMs: 0, staleCutoffDays: 7 },
+    });
+    const a = anomalies.find((x) => x.code === "tempering-coverage-below-minimum");
+    expect(a).toBeDefined();
+    expect(a.severity).toBe("warn");
+    expect(a.message).toMatch(/2 coverage layer\(s\)/);
+  });
+
+  it("emits tempering-scan-stale (severity=warn) when stale=true", () => {
+    const anomalies = detectWatchAnomalies({
+      ok: true,
+      runState: "idle",
+      counts: {},
+      artifacts: [],
+      tempering: { belowMinimum: 0, stale: true, latestScanAgeMs: 10 * 86400 * 1000, staleCutoffDays: 7 },
+    });
+    const a = anomalies.find((x) => x.code === "tempering-scan-stale");
+    expect(a).toBeDefined();
+    expect(a.severity).toBe("warn");
+    expect(a.message).toMatch(/10 days old/);
+  });
+
+  it("emits no tempering anomalies when tempering is null", () => {
+    const anomalies = detectWatchAnomalies({
+      ok: true,
+      runState: "idle",
+      counts: {},
+      artifacts: [],
+      tempering: null,
+    });
+    const temperingAnomalies = anomalies.filter((x) => x.code.startsWith("tempering-"));
+    expect(temperingAnomalies).toEqual([]);
+  });
+
+  it("does not emit tempering-coverage-below-minimum when belowMinimum is 0", () => {
+    const anomalies = detectWatchAnomalies({
+      ok: true,
+      runState: "idle",
+      counts: {},
+      artifacts: [],
+      tempering: { belowMinimum: 0, stale: false, latestScanAgeMs: 0, staleCutoffDays: 7 },
+    });
+    expect(anomalies.find((x) => x.code === "tempering-coverage-below-minimum")).toBeUndefined();
+  });
+});
+
+// ─── recommendFromAnomalies — tempering cases ────────────────────────
+
+describe("recommendFromAnomalies — Tempering", () => {
+  it("returns a concrete action + forge_tempering_status command for below-minimum", () => {
+    const snap = { tempering: { belowMinimum: 3 } };
+    const recs = recommendFromAnomalies(
+      [{ severity: "warn", code: "tempering-coverage-below-minimum", message: "x" }],
+      snap,
+    );
+    const rec = recs.find((r) => r.code === "tempering-coverage-below-minimum");
+    expect(rec).toBeDefined();
+    expect(rec.command).toBe("forge_tempering_status");
+    expect(rec.action).toMatch(/coverage layer/);
+  });
+
+  it("returns a concrete action + forge_tempering_scan command for stale", () => {
+    const recs = recommendFromAnomalies(
+      [{ severity: "warn", code: "tempering-scan-stale", message: "x" }],
+      { tempering: { stale: true } },
+    );
+    const rec = recs.find((r) => r.code === "tempering-scan-stale");
+    expect(rec).toBeDefined();
+    expect(rec.command).toBe("forge_tempering_scan");
+  });
+});
+
+// ─── runWatch report + compact hub event payload ─────────────────────
+
+describe("runWatch — tempering propagation", () => {
+  let project;
+  beforeEach(() => { project = makeProject(); });
+  afterEach(() => cleanup(project.dir));
+
+  it("includes the tempering block on the report itself", async () => {
+    seedTemperingScan(project.dir, { status: "amber", belowMinimum: 1 });
+    const report = await runWatch({ targetPath: project.dir, mode: "snapshot", recordHistory: false });
+    expect(report.ok).toBe(true);
+    expect(report.tempering).not.toBeNull();
+    expect(report.tempering.latestStatus).toBe("amber");
+    expect(report.tempering.belowMinimum).toBe(1);
+  });
+
+  it("emits a compact Tempering block on watch-snapshot-completed", async () => {
+    seedTemperingScan(project.dir, { status: "green", belowMinimum: 0 });
+    const emitted = [];
+    const eventBus = { emit: (type, data) => emitted.push({ type, data }) };
+    await runWatch({ targetPath: project.dir, mode: "snapshot", recordHistory: false, eventBus });
+    const completed = emitted.find((e) => e.type === "watch-snapshot-completed");
+    expect(completed).toBeDefined();
+    expect(completed.data.tempering).toMatchObject({
+      totalScans: 1,
+      latestStatus: "green",
+      belowMinimum: 0,
+      stale: false,
+    });
+    expect(completed.data.tempering.staleCutoffDays).toBe(7);
+  });
+
+  it("emits tempering: null when subsystem is uninitialized", async () => {
+    const emitted = [];
+    const eventBus = { emit: (type, data) => emitted.push({ type, data }) };
+    await runWatch({ targetPath: project.dir, mode: "snapshot", recordHistory: false, eventBus });
+    const completed = emitted.find((e) => e.type === "watch-snapshot-completed");
+    expect(completed.data.tempering).toBeNull();
+  });
+});
+
+// ─── handleStatus enrichment ─────────────────────────────────────────
+
+describe("handleStatus — coverage-vs-minima surfacing", () => {
+  let project;
+  beforeEach(() => { project = makeProject(); });
+  afterEach(() => cleanup(project.dir));
+
+  it("carries coverageMinima + coverageVsMinima on each scan summary", () => {
+    writeFileSync(resolve(project.dir, "package.json"), "{}", "utf-8");
+    mkdirSync(resolve(project.dir, "coverage"), { recursive: true });
+    writeFileSync(resolve(project.dir, "coverage", "lcov.info"),
+      "SF:src/services/weak.ts\nLF:100\nLH:60\nend_of_record\n", "utf-8");
+    handleScan({ projectDir: project.dir });
+    const status = handleStatus({ projectDir: project.dir });
+    const latest = status.scans[0];
+    expect(latest).toBeDefined();
+    expect(latest.coverageMinima).toMatchObject({ domain: 90 });
+    expect(Array.isArray(latest.coverageVsMinima)).toBe(true);
+    expect(latest.coverageVsMinima.length).toBeGreaterThan(0);
+  });
+});
+
+// ─── pforge smith sections ───────────────────────────────────────────
+
+describe("pforge smith — Tempering section", () => {
+  it("PowerShell pforge.ps1 has a Tempering section with scan + stale warnings", () => {
+    expect(pforgePs1).toMatch(/Tempering:/);
+    expect(pforgePs1).toMatch(/forge_tempering_scan/);
+    expect(pforgePs1).toMatch(/below minimum by ≥ 5 points|below min/i);
+    expect(pforgePs1).toMatch(/days old/);
+  });
+
+  it("bash pforge.sh has a Tempering section with scan + stale warnings", () => {
+    expect(pforgeSh).toMatch(/Tempering:/);
+    expect(pforgeSh).toMatch(/forge_tempering_scan/);
+    expect(pforgeSh).toMatch(/below minimum by ≥ 5 points|below min/i);
+    expect(pforgeSh).toMatch(/days old/);
+  });
+});

--- a/pforge.ps1
+++ b/pforge.ps1
@@ -3327,6 +3327,61 @@ function Invoke-Smith {
     }
 
     # ═══════════════════════════════════════════════════════════════
+    # 9. TEMPERING (Phase TEMPER-01 Slice 01.2)
+    # ═══════════════════════════════════════════════════════════════
+    # The Tempering subsystem (forge_tempering_scan → forge_tempering_status)
+    # parses existing coverage reports and flags layers below configured
+    # minima. Surfacing freshness + gap counts here gives the forge operator
+    # a one-glance answer to "is my test coverage honest?" without having
+    # to open the dashboard.
+    $temperingDir = Join-Path $RepoRoot ".forge/tempering"
+    Write-Host ""
+    Write-Host "Tempering:" -ForegroundColor Cyan
+
+    if (Test-Path $temperingDir) {
+        $scanFiles = @(Get-ChildItem -Path $temperingDir -Filter "scan-*.json" -File -ErrorAction SilentlyContinue |
+            Sort-Object LastWriteTime -Descending)
+
+        if ($scanFiles.Count -eq 0) {
+            Doctor-Pass "No Tempering scans yet — run 'forge_tempering_scan' to establish a baseline"
+        } else {
+            $latest = $scanFiles[0]
+            try {
+                $scan = Get-Content $latest.FullName -Raw | ConvertFrom-Json
+                $status = if ($scan.status) { "$($scan.status)" } else { "unknown" }
+                $ageDays = [Math]::Floor(((Get-Date) - $latest.LastWriteTime).TotalDays)
+                $gapCount = if ($scan.coverageVsMinima) { @($scan.coverageVsMinima).Count } else { 0 }
+                Doctor-Pass "$($scanFiles.Count) scan(s); latest: $status, $gapCount gap(s), $ageDays day(s) old"
+
+                # Stale-scan warning mirrors the watcher anomaly rule
+                # `tempering-scan-stale` (7-day cutoff).
+                if ($ageDays -ge 7) {
+                    Doctor-Warn "Latest scan is $ageDays days old" "Re-run 'forge_tempering_scan' — coverage drifts fast"
+                }
+
+                # Below-minimum warning mirrors the `tempering-coverage-below-minimum`
+                # watcher rule (≥ 5-point gap).
+                if ($scan.coverageVsMinima) {
+                    $belowMin = @($scan.coverageVsMinima | Where-Object { $_.gap -ge 5 })
+                    if ($belowMin.Count -gt 0) {
+                        Doctor-Warn "$($belowMin.Count) coverage layer(s) below minimum by ≥ 5 points" "Run 'forge_tempering_status' to inspect the gap report"
+                    }
+                }
+            } catch {
+                Doctor-Warn "Latest scan record could not be parsed" "File: $($latest.Name)"
+            }
+        }
+
+        # Config file — seeded on first scan, never overwritten.
+        $tempCfg = Join-Path $temperingDir "config.json"
+        if (Test-Path $tempCfg) {
+            Doctor-Pass "Tempering config present — enterprise minima active"
+        }
+    } else {
+        Doctor-Pass "Tempering inactive — no .forge/tempering/ directory yet"
+    }
+
+    # ═══════════════════════════════════════════════════════════════
     # SUMMARY
     # ═══════════════════════════════════════════════════════════════
     Write-Host ""

--- a/pforge.sh
+++ b/pforge.sh
@@ -2555,6 +2555,68 @@ cmd_doctor() {
     fi
 
     # ═══════════════════════════════════════════════════════════════
+    # TEMPERING (Phase TEMPER-01 Slice 01.2)
+    # ═══════════════════════════════════════════════════════════════
+    # The Tempering subsystem (forge_tempering_scan → forge_tempering_status)
+    # parses existing coverage reports and flags layers below configured
+    # minima. Surfacing freshness + gap counts here gives the forge operator
+    # a one-glance answer to "is my test coverage honest?" without having
+    # to open the dashboard.
+    echo ""
+    echo "Tempering:"
+    tempering_dir="$REPO_ROOT/.forge/tempering"
+    if [ -d "$tempering_dir" ]; then
+        # Find the newest scan-*.json by mtime
+        latest_scan=""
+        scan_count=0
+        for f in "$tempering_dir"/scan-*.json; do
+            [ -e "$f" ] || continue
+            scan_count=$((scan_count + 1))
+            if [ -z "$latest_scan" ] || [ "$f" -nt "$latest_scan" ]; then
+                latest_scan="$f"
+            fi
+        done
+
+        if [ "$scan_count" -eq 0 ]; then
+            doctor_pass "No Tempering scans yet — run 'forge_tempering_scan' to establish a baseline"
+        else
+            # Extract status + gap count — best-effort grep, no jq dep.
+            status=$(grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' "$latest_scan" 2>/dev/null | head -n1 | sed 's/.*"\([^"]*\)"$/\1/')
+            [ -z "$status" ] && status="unknown"
+            gap_count=$(grep -o '"layer"[[:space:]]*:' "$latest_scan" 2>/dev/null | wc -l | tr -d ' ')
+
+            # Age in days from mtime — portable across GNU/BSD stat.
+            if stat -c %Y "$latest_scan" >/dev/null 2>&1; then
+                mtime=$(stat -c %Y "$latest_scan")
+            else
+                mtime=$(stat -f %m "$latest_scan" 2>/dev/null || echo "0")
+            fi
+            now=$(date +%s)
+            age_days=$(( (now - mtime) / 86400 ))
+
+            doctor_pass "$scan_count scan(s); latest: $status, ${gap_count:-0} gap(s), $age_days day(s) old"
+
+            # Stale-scan warning mirrors the `tempering-scan-stale` watcher rule.
+            if [ "$age_days" -ge 7 ]; then
+                doctor_warn "Latest scan is $age_days days old" "Re-run 'forge_tempering_scan' — coverage drifts fast"
+            fi
+
+            # Below-minimum warning — count gap records with gap ≥ 5.
+            # Walks the file line-by-line looking for the "gap" field.
+            below_min=$(awk '/"gap"[[:space:]]*:/ { gsub(/[^0-9.]/,"",$0); if ($0+0 >= 5) c++ } END { print c+0 }' "$latest_scan" 2>/dev/null)
+            if [ "${below_min:-0}" -gt 0 ]; then
+                doctor_warn "$below_min coverage layer(s) below minimum by ≥ 5 points" "Run 'forge_tempering_status' to inspect the gap report"
+            fi
+        fi
+
+        if [ -f "$tempering_dir/config.json" ]; then
+            doctor_pass "Tempering config present — enterprise minima active"
+        fi
+    else
+        doctor_pass "Tempering inactive — no .forge/tempering/ directory yet"
+    fi
+
+    # ═══════════════════════════════════════════════════════════════
     # SUMMARY
     # ═══════════════════════════════════════════════════════════════
     echo ""


### PR DESCRIPTION
# TEMPER-01 Slice 01.2 — Tempering dashboard + watcher awareness

Closes **Phase TEMPER-01**. The foundation shipped in
[PR #54](https://github.com/srnichols/plan-forge/pull/54) is now visible
in three operator surfaces — still **zero writes to production source**,
still **no test runs**.

---

## What's in this PR

### Dashboard (`pforge-mcp/dashboard/`)

- New **Tempering tab** (`🛠 Tempering`) — read-only pane with 4 sections:
  1. Latest scan summary (status / age / gap / below-min counts)
  2. Coverage vs. minima progress bars per layer with minimum markers
  3. Gap report — worst-first files per below-minimum layer (top 10)
  4. Scan history (newest first)
- "Run scan" button → `POST /api/tool/forge_tempering_scan`
- Refresh → `POST /api/tool/forge_tempering_status`
- `state.tempering` seeded on client boot

### Watcher-tab Tempering chip row

Mirrors the Slice 03.2 Crucible row. Hidden when `.forge/tempering/` is
missing.

| Chip | Meaning |
|------|---------|
| `Σ N` | Total scans |
| `● status` | Latest scan status (green/amber/no-data/error) |
| `⚠ N below min` | Layers ≥ 5 points below minimum |
| `⌂ N gaps` | Total gap records in latest scan |
| `⏱ Nd stale?` | Age + stale indicator |

`data-testid="watcher-tempering-row"`

### Watcher snapshot + hub event

- `buildWatchSnapshot` includes a `tempering` block (mirrors `crucible`;
  `null` when uninitialized)
- `watch-snapshot-completed` payloads carry a compact `tempering`
  summary (primitives only — safe for bandwidth-constrained WS clients)

### Two new anomaly rules

| Code | Severity | Trigger | Suggested command |
|------|----------|---------|-------------------|
| `tempering-coverage-below-minimum` | `warn` | Any layer ≥ 5 points below min | `forge_tempering_status` |
| `tempering-scan-stale` | `warn` | Latest scan older than `TEMPERING_SCAN_STALE_DAYS` (7) | `forge_tempering_scan` |

Both wired in `recommendFromAnomalies` with concrete actions.

### `pforge smith` (PowerShell + bash)

New **Tempering** section in the doctor surfaces the same information
as the dashboard:

- Scan count + latest status + age
- Stale warning at ≥ 7 days (mirrors the watcher rule)
- Below-minimum warning at ≥ 5 points (mirrors the watcher rule)
- Config-file presence indicator

### Scan record enrichment

- `coverageMinima` snapshot persisted on every scan record so
  downstream tooling can render without re-reading `config.json`
- `forge_tempering_status` response now includes `coverageMinima` and
  full `coverageVsMinima` gap report (`files` already bounded top-10
  by `computeGaps`)

---

## Validation

- **Full test suite**: 1145/1145 passing (**+29 new**)
  - `tests/tempering-watcher.test.mjs` — 20 tests covering snapshot
    propagation, anomaly detection, recommendation mapping, compact
    event payloads, and `pforge smith` section presence
  - `tests/tempering-dashboard.test.mjs` — 9 tests pinning the
    dashboard tab structure, JS wiring, REST routing, and Watcher-row
    contract
  - `tests/server.test.mjs` total tab count assertion updated
    18 → 19 (new Tempering tab)
- `node server.mjs --validate` → 45 tools registered
- `forge_sweep` equivalent — no TODO / FIXME / stub / placeholder
  markers in touched code
- No schema churn — only additive snapshot/report fields

---

## Files changed

| File | Change |
|------|--------|
| `pforge-mcp/dashboard/index.html` | New Tempering tab + tab button |
| `pforge-mcp/dashboard/app.js` | `loadTemperingStatus`, `runTemperingScan`, `renderTemperingPanel`, Watcher-tab row, `state.tempering` |
| `pforge-mcp/orchestrator.mjs` | `tempering` block on snapshot + report, 2 anomaly rules + 2 recommendations, compact event payload |
| `pforge-mcp/server.mjs` | MCP_ONLY_TOOLS entries for both Tempering tools |
| `pforge-mcp/tempering.mjs` | Scan record `coverageMinima` snapshot; `handleStatus` surfaces `coverageVsMinima` |
| `pforge.ps1` | `smith` command: new Tempering section |
| `pforge.sh` | `smith` command: new Tempering section |
| `pforge-mcp/tests/tempering-watcher.test.mjs` | NEW — 20 tests |
| `pforge-mcp/tests/tempering-dashboard.test.mjs` | NEW — 9 tests |
| `pforge-mcp/tests/server.test.mjs` | Tab count 18 → 19 |
| `CHANGELOG.md` | v2.42.0 entry appended with Slice 01.2 |
| `docs/plans/Phase-TEMPER-01.md` | `status: in_progress` → `status: finalized` |

---

## Scope contract held

- ❌ Test execution (TEMPER-02)
- ❌ Bug creation (TEMPER-04)
- ❌ Production source edits (never in this subsystem)
- ❌ `forge_liveguard_run` wire-in (TEMPER-03)
- ❌ Visual analyzer (TEMPER-04)
- ❌ Accessibility / contract tests (TEMPER-03)

---

## Next

**Phase TEMPER-01 is finalized.** Next phase is **TEMPER-02** — the
executor: adapters for each supported stack that actually run the test
suite and feed the existing scan contract with fresh numbers. Same
principle: separate PR, separate slices, one at a time.
