### PR TITLE
fix(ci): eliminate BASELINE_FAILURES=10 workaround by fixing the 9 underlying drifts (#155)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -102,20 +102,17 @@ jobs:
         # - Quorum-config-precedence: bumped timeout + Windows skip for 2 slow probes
         # If a NEW test fails, fix it — don't bump this number.
         #
-        # Phase-COST-TOKEN-COVERAGE (PR #154, 2026-05-06): Bumped 0 → 10 to
-        # acknowledge integration smoke tests that spawn end-to-end pforge
-        # runs requiring COPILOT_GITHUB_TOKEN, which is not provisioned in
-        # the GitHub Actions environment. Failures are environmental
-        # (`fatal: not a git repository`, `Error: No authentication
-        # information found.`), not regressions in the cost-service code
-        # path under test by this PR. The 10 failures are all "Slice 1:
-        # Quorum Probe — FAILED" / "Slice 1: Fix the login bug — FAILED"
-        # patterns from the integration probes. Tracking issue: file with
-        # `forge_meta_bug_file` after merge for the proper fix (either
-        # provision COPILOT_GITHUB_TOKEN as an Actions secret, or make the
-        # probes skip cleanly when no token is present).
+        # Issue #155 (2026-05-06): The 10-baseline bump that PR #154 added
+        # has been removed. The 9 "CI-only" failures had nothing to do with
+        # COPILOT_GITHUB_TOKEN — they were version-string drift, schema drift
+        # in tools.json (forge_tempering_drain / forge_triage_route metadata
+        # vs the test contract), the github-introspect check-count being
+        # bumped from 8 → 9 without updating the assertion, and a path-test
+        # that hardcoded "C:\..." which Linux CI resolved as a relative
+        # filename. All fixed inline. Ceiling stays at 0 — any new failure
+        # is a real regression worth investigating.
         env:
-          BASELINE_FAILURES: "10"
+          BASELINE_FAILURES: "0"
         run: |
           set +e
           npx vitest run --reporter=json --outputFile=vitest-results.json 2>&1 | tail -200

--- a/docs/manual/assets/diagrams/discovery-harness-four-pass.svg
+++ b/docs/manual/assets/diagrams/discovery-harness-four-pass.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 280" fill="none" role="img" aria-labelledby="dhfp-title dhfp-desc">
+  <title id="dhfp-title">Discovery Harness — 4-pass build sequence</title>
+  <desc id="dhfp-desc">Four sequential passes: Pass 1 (Harness) crawls routes with Node + Playwright and emits structured JSON; Pass 2 (Wrapper) transforms that JSON into Crucible smelts; Pass 3 (Execute) runs slice-by-slice with test gates and Tempering; Pass 4 (Auto-smelt) converts Tempering failures into new smelts with no human triage required, closing the loop.</desc>
+  <style>
+    text { font-family: 'Inter', sans-serif; }
+    .node { rx: 8; ry: 8; stroke-width: 1.5; }
+    .arrow { stroke: #fbbf24; stroke-width: 1.5; fill: none; marker-end: url(#dhfp-ah); }
+    .arrow-loop { stroke: #fb7185; stroke-width: 1.5; fill: none; stroke-dasharray: 6 4; marker-end: url(#dhfp-ah-rose); }
+    .label { font-size: 10px; fill: #94a3b8; }
+    .micro { font-size: 9px; fill: #64748b; font-family: 'JetBrains Mono', monospace; }
+    .title-text { font-size: 12px; fill: #e2e8f0; font-weight: 600; }
+    .pass-num { font-size: 20px; font-weight: 800; font-family: 'Inter', sans-serif; }
+    .phase { font-size: 9px; fill: #f59e0b; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+    .heading { font-size: 11px; fill: #64748b; font-weight: 600; letter-spacing: 0.1em; }
+  </style>
+  <defs>
+    <marker id="dhfp-ah" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#fbbf24" />
+    </marker>
+    <marker id="dhfp-ah-rose" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#fb7185" />
+    </marker>
+  </defs>
+
+  <!-- Heading -->
+  <text x="410" y="24" class="heading" text-anchor="middle">THE 4-PASS BUILD</text>
+
+  <!-- Pass 1: Harness -->
+  <circle cx="110" cy="105" r="38" fill="#451a03" fill-opacity="0.5" stroke="#b45309" stroke-width="2" />
+  <text x="110" y="112" class="pass-num" text-anchor="middle" fill="#fbbf24">1</text>
+  <text x="110" y="165" class="title-text" text-anchor="middle">Harness</text>
+  <text x="110" y="181" class="micro" text-anchor="middle">Node + Playwright</text>
+  <text x="110" y="197" class="micro" text-anchor="middle">route crawl + audit</text>
+
+  <!-- Pass 1 detail box -->
+  <rect x="20" y="218" width="180" height="50" class="node" fill="#0f172a" stroke="#475569" />
+  <text x="110" y="233" class="label" text-anchor="middle">Outputs .forge/audits/</text>
+  <text x="110" y="248" class="micro" text-anchor="middle">HTTP status · title · h1</text>
+  <text x="110" y="263" class="micro" text-anchor="middle">placeholders · broken links</text>
+
+  <!-- Arrow 1 → 2 -->
+  <line x1="155" y1="105" x2="295" y2="105" class="arrow" />
+  <text x="225" y="96" class="label" text-anchor="middle">findings[]</text>
+
+  <!-- Pass 2: Wrapper -->
+  <circle cx="330" cy="105" r="38" fill="#451a03" fill-opacity="0.5" stroke="#b45309" stroke-width="2" />
+  <text x="330" y="112" class="pass-num" text-anchor="middle" fill="#fbbf24">2</text>
+  <text x="330" y="165" class="title-text" text-anchor="middle">Wrapper</text>
+  <text x="330" y="181" class="micro" text-anchor="middle">JSON → Crucible</text>
+  <text x="330" y="197" class="micro" text-anchor="middle">forge_crucible_submit</text>
+
+  <!-- Pass 2 detail box -->
+  <rect x="240" y="218" width="180" height="50" class="node" fill="#0f172a" stroke="#475569" />
+  <text x="330" y="233" class="label" text-anchor="middle">Severity triage</text>
+  <text x="330" y="248" class="micro" text-anchor="middle">bug · spec · classifier lanes</text>
+  <text x="330" y="263" class="micro" text-anchor="middle">structured smelt input</text>
+
+  <!-- Arrow 2 → 3 -->
+  <line x1="375" y1="105" x2="515" y2="105" class="arrow" />
+  <text x="445" y="96" class="label" text-anchor="middle">smelts</text>
+
+  <!-- Pass 3: Execute -->
+  <circle cx="550" cy="105" r="38" fill="#022c22" fill-opacity="0.6" stroke="#047857" stroke-width="2" />
+  <text x="550" y="112" class="pass-num" text-anchor="middle" fill="#34d399">3</text>
+  <text x="550" y="165" class="title-text" text-anchor="middle">Execute</text>
+  <text x="550" y="181" class="micro" text-anchor="middle">slices + temper</text>
+  <text x="550" y="197" class="micro" text-anchor="middle">forge_run_plan</text>
+
+  <!-- Pass 3 detail box -->
+  <rect x="460" y="218" width="180" height="50" class="node" fill="#0f172a" stroke="#475569" />
+  <text x="550" y="233" class="label" text-anchor="middle">Slice-by-slice gates</text>
+  <text x="550" y="248" class="micro" text-anchor="middle">Tempering re-audit</text>
+  <text x="550" y="263" class="micro" text-anchor="middle">LiveGuard hooks</text>
+
+  <!-- Arrow 3 → 4 -->
+  <line x1="595" y1="105" x2="735" y2="105" class="arrow" />
+  <text x="665" y="96" class="label" text-anchor="middle">failures</text>
+
+  <!-- Pass 4: Auto-smelt -->
+  <circle cx="770" cy="105" r="38" fill="#4c0519" fill-opacity="0.6" stroke="#be123c" stroke-width="2" />
+  <text x="770" y="112" class="pass-num" text-anchor="middle" fill="#fb7185">4</text>
+  <text x="770" y="165" class="title-text" text-anchor="middle">Auto-smelt</text>
+  <text x="770" y="181" class="micro" text-anchor="middle">no human triage</text>
+  <text x="770" y="197" class="micro" text-anchor="middle">forge_tempering_drain</text>
+
+  <!-- Pass 4 detail box -->
+  <rect x="680" y="218" width="180" height="50" class="node" fill="#0f172a" stroke="#475569" />
+  <text x="770" y="233" class="label" text-anchor="middle">Bug registry</text>
+  <text x="770" y="248" class="micro" text-anchor="middle">re-enters Discovery</text>
+  <text x="770" y="263" class="micro" text-anchor="middle">next round ≤ maxRounds=5</text>
+
+  <!-- Loop arrow: Auto-smelt back to Harness -->
+  <path d="M770,143 Q770,50 110,50 Q72,50 72,67" class="arrow-loop" />
+  <text x="440" y="43" class="label" style="fill:#fb7185;" text-anchor="middle">closed loop (until convergence)</text>
+</svg>

--- a/docs/manual/assets/diagrams/triage-three-lane-funnel.svg
+++ b/docs/manual/assets/diagrams/triage-three-lane-funnel.svg
@@ -1,0 +1,99 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 360" fill="none">
+  <title>Triage Three-Lane Funnel — Findings routed to Bug, Spec, and Classifier lanes</title>
+  <style>
+    text { font-family: 'Inter', sans-serif; }
+    .node { rx: 8; ry: 8; stroke-width: 1.5; }
+    .arrow { stroke: #475569; stroke-width: 1.5; fill: none; marker-end: url(#ttlah); }
+    .arrow-bug  { stroke: #fb7185; stroke-width: 1.5; fill: none; marker-end: url(#ttlahbug); }
+    .arrow-spec { stroke: #fbbf24; stroke-width: 1.5; fill: none; marker-end: url(#ttlahspec); }
+    .arrow-cls  { stroke: #c4b5fd; stroke-width: 1.5; fill: none; marker-end: url(#ttlahcls); }
+    .label  { font-size: 10px; fill: #94a3b8; }
+    .small  { font-size: 9px;  fill: #cbd5e1; }
+    .tiny   { font-size: 8px;  fill: #94a3b8; font-style: italic; }
+    .title  { font-size: 11px; fill: #e2e8f0; font-weight: 600; }
+    .phase  { font-size: 9px;  fill: #f59e0b; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+    .lane   { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; }
+    .count  { font-size: 9px;  fill: #94a3b8; font-style: italic; }
+  </style>
+  <defs>
+    <marker id="ttlah" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#475569" />
+    </marker>
+    <marker id="ttlahbug" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#fb7185" />
+    </marker>
+    <marker id="ttlahspec" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#fbbf24" />
+    </marker>
+    <marker id="ttlahcls" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="#c4b5fd" />
+    </marker>
+  </defs>
+
+  <!-- ── INPUT: Findings ── -->
+  <text x="100" y="20" class="phase" text-anchor="middle">INPUT</text>
+  <rect x="20" y="30" width="160" height="65" class="node" fill="#0f172a" stroke="#fbbf24" />
+  <text x="100" y="52" class="title" text-anchor="middle">Findings</text>
+  <text x="100" y="68" class="label" text-anchor="middle">content-audit results</text>
+  <text x="100" y="83" class="label" text-anchor="middle">severity · type · url</text>
+
+  <!-- Findings → Triage arrow -->
+  <path d="M180,62 L250,62" class="arrow" />
+  <text x="215" y="55" class="label" text-anchor="middle">findings[]</text>
+
+  <!-- ── TRIAGE ── -->
+  <text x="320" y="20" class="phase" text-anchor="middle">TRIAGE</text>
+  <rect x="250" y="30" width="140" height="65" class="node" fill="#0f172a" stroke="#fbbf24" />
+  <text x="320" y="52" class="title" text-anchor="middle">forge_triage_route</text>
+  <text x="320" y="68" class="label" text-anchor="middle">classify each finding</text>
+  <text x="320" y="83" class="label" text-anchor="middle">lane + confidence score</text>
+
+  <!-- Funnel neck lines -->
+  <line x1="390" y1="50" x2="430" y2="50" stroke="#475569" stroke-width="1" stroke-dasharray="3 2" />
+  <line x1="390" y1="62" x2="430" y2="62" stroke="#475569" stroke-width="1" stroke-dasharray="3 2" />
+  <line x1="390" y1="74" x2="430" y2="74" stroke="#475569" stroke-width="1" stroke-dasharray="3 2" />
+
+  <!-- ── Funnel shape ── -->
+  <!-- Fan-out arrows from triage to three lanes -->
+  <path d="M390,50 Q415,50 430,80" class="arrow-bug"  />
+  <path d="M390,62 L430,180"        class="arrow-spec" />
+  <path d="M390,74 Q415,74 430,280" class="arrow-cls"  />
+
+  <!-- ── LANE 1: Bug ── -->
+  <text x="590" y="56" class="lane" style="fill:#fb7185;" text-anchor="middle">Lane 1 · Bug</text>
+  <rect x="430" y="65" width="310" height="80" class="node" fill="#0f172a" stroke="#fb7185" />
+  <text x="585" y="87"  class="title" text-anchor="middle">forge_bug_register</text>
+  <text x="585" y="103" class="label" text-anchor="middle">Fingerprint-deduped bug registry entry</text>
+  <text x="585" y="118" class="label" text-anchor="middle">severity · repro steps · auto-fix candidate</text>
+  <text x="585" y="133" class="count" text-anchor="middle">triggers: tempering drain → spawnWorker</text>
+
+  <!-- ── LANE 2: Spec ── -->
+  <text x="590" y="160" class="lane" style="fill:#fbbf24;" text-anchor="middle">Lane 2 · Spec</text>
+  <rect x="430" y="165" width="310" height="80" class="node" fill="#0f172a" stroke="#fbbf24" />
+  <text x="585" y="187" class="title" text-anchor="middle">forge_crucible_submit</text>
+  <text x="585" y="203" class="label" text-anchor="middle">Re-smelt finding as a new feature smelt</text>
+  <text x="585" y="218" class="label" text-anchor="middle">rawIdea → lane inference → interview</text>
+  <text x="585" y="233" class="count" text-anchor="middle">triggers: Crucible → harden → execute pipeline</text>
+
+  <!-- ── LANE 3: Classifier ── -->
+  <text x="590" y="264" class="lane" style="fill:#c4b5fd;" text-anchor="middle">Lane 3 · Classifier</text>
+  <rect x="430" y="269" width="310" height="75" class="node" fill="#0f172a" stroke="#c4b5fd" />
+  <text x="585" y="291" class="title" text-anchor="middle">.forge/audits/&lt;ts&gt;.json</text>
+  <text x="585" y="307" class="label" text-anchor="middle">Archived for human review or future training</text>
+  <text x="585" y="322" class="label" text-anchor="middle">confidence below threshold, or ambiguous intent</text>
+  <text x="585" y="337" class="count" text-anchor="middle">no auto-action — human decides next step</text>
+
+  <!-- ── Confidence legend ── -->
+  <rect x="20" y="130" width="200" height="90" class="node" fill="#020617" stroke="#475569" stroke-dasharray="2 3" />
+  <text x="120" y="150" class="title" style="fill:#94a3b8;" text-anchor="middle">Confidence Routing</text>
+  <text x="30"  y="168" class="small" style="fill:#fb7185;">≥ 0.85 → Bug lane (clear defect)</text>
+  <text x="30"  y="184" class="small" style="fill:#fbbf24;">≥ 0.70 → Spec lane (enhancement)</text>
+  <text x="30"  y="200" class="small" style="fill:#c4b5fd;">&lt; 0.70 → Classifier (review queue)</text>
+  <text x="120" y="215" class="tiny"  text-anchor="middle">thresholds configurable in .forge.json</text>
+
+  <!-- ── maxRounds note ── -->
+  <rect x="20" y="245" width="200" height="55" class="node" fill="#020617" stroke="#fbbf24" stroke-dasharray="2 3" />
+  <text x="120" y="265" class="title" style="fill:#94a3b8;" text-anchor="middle">Convergence</text>
+  <text x="120" y="281" class="label" text-anchor="middle">Loop repeats until 0 Findings</text>
+  <text x="120" y="296" class="label" text-anchor="middle">or maxRounds reached (default 5)</text>
+</svg>

--- a/docs/manual/audit-loop.html
+++ b/docs/manual/audit-loop.html
@@ -120,6 +120,28 @@ pforge audit-loop --env=staging</code></pre>
         <h2>Dashboard</h2>
         <p>The audit-loop toggle in the dashboard persists to <code>.forge.json#audit</code> — not session-scoped. This matches the pattern used by Forge-Master prefs (<code>.forge/fm-prefs.json</code>) and the quorum advisory toggle.</p>
 
+        <h2 id="discovery-harness">Discovery Harness Implementation</h2>
+        <p>The discovery harness is the engine that turns a running dev server into a stream of structured findings. It uses a 4-pass build sequence — crawl, wrap, execute, auto-smelt — to close the loop between bug discovery and bug resolution with no human triage required.</p>
+
+        <img src="assets/diagrams/discovery-harness-four-pass.svg" alt="Discovery Harness 4-pass build sequence: Pass 1 (Harness) crawls routes with Node + Playwright, Pass 2 (Wrapper) transforms JSON into Crucible smelts, Pass 3 (Execute) runs slices with Tempering, Pass 4 (Auto-smelt) converts failures into new smelts" class="diagram-img diagram-img-md my-4" />
+
+        <h3>Pass 1 — Harness (Node + Playwright)</h3>
+        <p>A headless Playwright browser crawls every route exposed by the dev server. For each page the harness records HTTP status, document title, <code>h1</code> text, word count, placeholder markers (e.g. <code>Coming soon</code>, <code>TODO</code>), broken links, and client-shell detection for hydrated SPAs. Results are written as structured JSON to <code>.forge/audits/</code>.</p>
+        <p>Representative example: a marketing site with 47 routes produces 12 findings on its first pass — three placeholder headings, two broken anchor links, four pages returning non-200 status codes, and three pages with zero meaningful content.</p>
+
+        <h3>Pass 2 — Wrapper (JSON → Crucible)</h3>
+        <p>Each finding from Pass 1 is transformed into a Crucible smelt via <code>forge_crucible_submit</code>. The wrapper applies severity triage, routing findings through the three-lane classifier (bug, spec, classifier) before packaging them as structured smelt input with enough context for the hardener to produce actionable plan slices.</p>
+
+        <h3>Pass 3 — Execute (Slices + Tempering)</h3>
+        <p>The hardened plan runs slice-by-slice through <code>forge_run_plan</code>. Each slice carries its own validation gate and Tempering re-audit. LiveGuard hooks fire between slices, catching regressions before they compound.</p>
+
+        <h3>Pass 4 — Auto-smelt (Closed Loop)</h3>
+        <p>Any Tempering failures from Pass 3 are converted into new smelts via <code>forge_tempering_drain</code> and re-entered into the bug registry — no human triage required. The loop iterates until convergence (zero new findings) or the configured <code>maxRounds</code> limit (default 5) is reached.</p>
+
+        <div class="callout callout-info">
+          <strong>Further reading.</strong> For a real-world walkthrough of the 4-pass sequence applied to a production Next.js site, see the blog post <a href="../../blog/the-loop-that-never-ends.html">The Loop That Never Ends</a>.
+        </div>
+
         <h2>Design Decisions</h2>
         <ul>
           <li><strong>Classifier proposals are local files</strong> (v2.80): Written to <code>.forge/audits/</code> as JSON artifacts. GitHub PR creation deferred to v2.81+.</li>

--- a/pforge-mcp/capabilities.mjs
+++ b/pforge-mcp/capabilities.mjs
@@ -605,11 +605,11 @@ export const TOOL_METADATA = {
   forge_tempering_drain: {
     intent: ["tempering", "audit", "drain", "loop"],
     aliases: ["audit-loop", "drain-loop", "tempering-drain"],
-    cost: "medium",
+    cost: "high",
     maxConcurrent: 1,
     addedIn: "2.80.0",
     prerequisites: [".forge.json exists", "dev server running (for content-audit scanner)"],
-    produces: [".forge/audits/dev-*.json"],
+    produces: [".forge/audits/dev-*.json", ".forge/audits/dev-<ts>.json", ".forge/tempering/drain-history.jsonl"],
     consumes: [".forge.json#audit", ".forge/tempering/"],
     sideEffects: [
       "filesystem-write (audit artifacts)",
@@ -618,6 +618,8 @@ export const TOOL_METADATA = {
       "may submit Crucible smelts for spec-lane findings",
     ],
     errors: {
+      MISSING_PROJECTDIR: { message: "projectDir required", recovery: "Pass `path` or invoke from a project directory" },
+      MAX_ROUNDS_EXCEEDED: { message: "Drain loop hit maxRounds without converging", recovery: "Inspect .forge/tempering/drain-history.jsonl for the per-round delta; raise maxRounds (default 5) or fix the persistent finding causing non-convergence" },
       PRODUCTION_BLOCKED: { message: "Production environment is forbidden", recovery: "Use --env=dev or --env=staging" },
       NO_SCANNERS: { message: "No scanners matched the requested set", recovery: "Omit scanners param to run all available scanners" },
     },
@@ -637,7 +639,7 @@ export const TOOL_METADATA = {
     consumes: [],
     sideEffects: [],
     errors: {
-      INVALID_FINDING: { message: "Finding object is required with at least a title field", recovery: "Provide a finding object from a scanner result" },
+      MISSING_FINDING: { message: "Finding object is required with at least a title field", recovery: "Provide a finding object from a scanner result" },
     },
     example: {
       input: { finding: { title: "Missing h1 on /about", scanner: "content-audit", severity: "medium" } },

--- a/pforge-mcp/tests/changelog-format.test.mjs
+++ b/pforge-mcp/tests/changelog-format.test.mjs
@@ -72,22 +72,47 @@ describe("CHANGELOG.md — heading format (em-dash required for 2.85.0+ entries)
 });
 
 describe("CHANGELOG.md — release marker presence", () => {
-  it("contains a [2.90.10] heading", () => {
-    const has = /##\s+\[2\.90\.10\]/.test(changelog);
-    expect(has, "Missing ## [2.90.10] heading in CHANGELOG.md").toBe(true);
+  // Read the most recently-released version from CHANGELOG.md (first dated
+  // bracketed heading after [Unreleased]) and assert it's present. Asserting
+  // a hardcoded version number broke every release that didn't remember to
+  // bump this file (was: hardcoded 2.90.6 → broke at 2.90.7; bumped to 2.90.10
+  // → broke at 2.91.0-dev). Drift-proof check instead.
+  const releasedVersionMatch = changelog.match(/##\s+\[(\d+\.\d+\.\d+(?:-[\w.]+)?)\]\s*[—-]/);
+  it("contains a properly-formatted released version heading after [Unreleased]", () => {
+    expect(
+      releasedVersionMatch,
+      "CHANGELOG.md must contain at least one ## [X.Y.Z] — heading documenting a shipped release"
+    ).not.toBeNull();
   });
 });
 
 describe("VERSION and package.json consistency", () => {
-  it("VERSION file reads 2.90.10", () => {
-    expect(version).toBe("2.90.10");
+  // Don't hardcode a target version — that creates a drift trap on every
+  // release. Instead enforce the actual cross-file invariant: VERSION must
+  // match pforge-mcp/package.json, and both must be a recognisable
+  // semver (clean release or `-dev`).
+  it("VERSION file is a valid semver (optionally with -dev suffix)", () => {
+    expect(version).toMatch(/^\d+\.\d+\.\d+(?:-[\w.]+)?$/);
   });
 
-  it("pforge-mcp/package.json version reads 2.90.10", () => {
-    expect(pkg.version).toBe("2.90.10");
+  it("pforge-mcp/package.json version is a valid semver (optionally with -dev suffix)", () => {
+    expect(pkg.version).toMatch(/^\d+\.\d+\.\d+(?:-[\w.]+)?$/);
   });
 
-  it("VERSION file matches pforge-mcp/package.json version", () => {
+  it("VERSION file matches pforge-mcp/package.json version (no drift)", () => {
     expect(version).toBe(pkg.version);
+  });
+
+  it("when VERSION is a clean release (no -dev), CHANGELOG must contain a matching heading (release-tag invariant)", () => {
+    if (/-dev$/.test(version)) {
+      // Dev cycles legitimately have no matching CHANGELOG heading until cut.
+      return;
+    }
+    const escaped = version.replace(/\./g, "\\.");
+    const re = new RegExp(`##\\s+\\[${escaped}\\]\\s*[—-]`);
+    expect(
+      re.test(changelog),
+      `VERSION reads ${version} (clean release) but CHANGELOG.md has no matching ## [${version}] — heading. Cut the release entry before tagging.`
+    ).toBe(true);
   });
 });

--- a/pforge-mcp/tests/github-introspect.test.mjs
+++ b/pforge-mcp/tests/github-introspect.test.mjs
@@ -158,9 +158,13 @@ describe("inspectGithubStack — shape", () => {
     expect(r.summary.total).toBe(r.checks.length);
   });
 
-  it("returns 8 checks by default, 10 with extra:true", () => {
-    expect(inspectGithubStack(GREEN).checks).toHaveLength(8);
-    expect(inspectGithubStack(GREEN, { extra: true }).checks).toHaveLength(10);
+  it("returns 9 checks by default, 11 with extra:true (Phase GITHUB-A scope)", () => {
+    // Default: copilot-instructions, agents-md, instructions-dir, prompts-dir,
+    //          vscode-mcp, actions-workflows, github-remote, gh-cli,
+    //          copilot-coding-agent-assignable.
+    // Extra adds: copilot-instructions-depth, instructions-applyto.
+    expect(inspectGithubStack(GREEN).checks).toHaveLength(9);
+    expect(inspectGithubStack(GREEN, { extra: true }).checks).toHaveLength(11);
   });
 
   it("every check row has id, label, status, detail", () => {

--- a/pforge-mcp/tests/github-metrics.test.mjs
+++ b/pforge-mcp/tests/github-metrics.test.mjs
@@ -58,8 +58,13 @@ describe("parseDateArg", () => {
   it("parses Nd shorthand", () => {
     const result = parseDateArg("7d");
     expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-    const diff = Math.round((Date.now() - new Date(result).getTime()) / 86400000);
-    expect(diff).toBeCloseTo(7, 0);
+    // Compare ISO calendar dates, not millisecond diffs — Math.round on
+    // (now - midnightUTC) flips between 7 and 8 days depending on the
+    // UTC time-of-day the test runs at, which made this assertion flaky.
+    const expected = new Date();
+    expected.setUTCDate(expected.getUTCDate() - 7);
+    const expectedIso = expected.toISOString().slice(0, 10);
+    expect(result).toBe(expectedIso);
   });
 
   it("passes ISO date through unchanged", () => {

--- a/pforge-mcp/tests/parser.test.mjs
+++ b/pforge-mcp/tests/parser.test.mjs
@@ -103,7 +103,15 @@ describe("parsePlan", () => {
   });
 
   it("throws for paths outside project directory", () => {
-    expect(() => parsePlan("C:\\Windows\\System32\\evil.md")).toThrow(
+    // Use a platform-correct absolute path that genuinely resolves outside
+    // any plausible project root. Hardcoding Windows-style "C:\\Windows\\..."
+    // failed on Linux CI because Node's `resolve()` treats "C:\\..." as a
+    // relative filename on POSIX, so the path ended up *inside* projectRoot
+    // and the guard never fired — the read just hit ENOENT instead.
+    const outsidePath = process.platform === "win32"
+      ? "C:\\Windows\\System32\\evil.md"
+      : "/etc/passwd-evil.md";
+    expect(() => parsePlan(outsidePath)).toThrow(
       /must be within project directory/
     );
   });

--- a/pforge-mcp/tools.json
+++ b/pforge-mcp/tools.json
@@ -563,7 +563,7 @@
   },
   {
     "name": "forge_run_plan",
-    "description": "Execute a hardened plan — spawn CLI workers for each slice, validate at every boundary, track tokens. Supports Full Auto (gh copilot CLI) and Assisted (human + automated gates) modes. Use --estimate for cost prediction without executing.",
+    "description": "Execute a hardened plan — spawn CLI workers for each slice, validate at every boundary, track tokens. Supports Full Auto (gh copilot CLI) and Assisted (human + automated gates) modes. Use --estimate for cost prediction without executing. Crucible-bypass: pass manualImport:true (or --manual-import on the CLI) to run plans that don't carry a crucibleId frontmatter — e.g. hand-drafted hotfix plans (bug #126).",
     "inputSchema": {
       "type": "object",
       "properties": {

--- a/pforge-mcp/tools.json
+++ b/pforge-mcp/tools.json
@@ -2297,7 +2297,7 @@
       "drain-loop",
       "tempering-drain"
     ],
-    "cost": "medium",
+    "cost": "high",
     "maxConcurrent": 1,
     "addedIn": "2.80.0",
     "prerequisites": [
@@ -2305,7 +2305,9 @@
       "dev server running (for content-audit scanner)"
     ],
     "produces": [
-      ".forge/audits/dev-*.json"
+      ".forge/audits/dev-*.json",
+      ".forge/audits/dev-<ts>.json",
+      ".forge/tempering/drain-history.jsonl"
     ],
     "consumes": [
       ".forge.json#audit",
@@ -2318,6 +2320,14 @@
       "may submit Crucible smelts for spec-lane findings"
     ],
     "errors": {
+      "MISSING_PROJECTDIR": {
+        "message": "projectDir required",
+        "recovery": "Pass `path` or invoke from a project directory"
+      },
+      "MAX_ROUNDS_EXCEEDED": {
+        "message": "Drain loop hit maxRounds without converging",
+        "recovery": "Inspect .forge/tempering/drain-history.jsonl for the per-round delta; raise maxRounds (default 5) or fix the persistent finding causing non-convergence"
+      },
       "PRODUCTION_BLOCKED": {
         "message": "Production environment is forbidden",
         "recovery": "Use --env=dev or --env=staging"
@@ -2423,7 +2433,7 @@
     "consumes": [],
     "sideEffects": [],
     "errors": {
-      "INVALID_FINDING": {
+      "MISSING_FINDING": {
         "message": "Finding object is required with at least a title field",
         "recovery": "Provide a finding object from a scanner result"
       }


### PR DESCRIPTION
## Summary

PR #154's bump of \BASELINE_FAILURES\ 0 → 10 was a misdiagnosis. Investigation showed the 9 'CI-only' failures had nothing to do with \COPILOT_GITHUB_TOKEN\ — they were pure code/data drift that happened to be invisible locally because the dev machine had a more current state.

## What was actually broken

| Test | Real cause |
|---|---|
| \changelog-format\ × 3 | Hardcoded version (\2.90.10\); current is \2.91.0-dev\ |
| \crucible-error-message\ × 1 | tools.json description lost \manualImport:true\ mention |
| \github-introspect\ × 1 | Default check count went 8 → 9, assertion not updated |
| \mcp-audit-tools\ × 4 | tools.json schema drift on \orge_tempering_drain\ + \orge_triage_route\ (cost, errors, produces) |
| \parser\ × 1 | Hardcoded \C:\\Windows\\...\ path which Linux CI's \path.resolve\ treats as a relative filename — guard never fires |

## Fix philosophy

Per the architecture principles: **don't keep a 'we'll fix it later' shortcut**. The \BASELINE_FAILURES=10\ ceiling silently hid 9 distinct real bugs and gave any new regression cover up to that limit. Fix the actual problems, return the gate to 0, restore signal.

Drift-proof the version assertions so this can't happen again at the next release: instead of hardcoding the current version, assert the **invariant** (VERSION ↔ package.json must agree, and when clean — no \-dev\ — must have a CHANGELOG entry).

## Verification

- \
px vitest run\ against the 5 affected files → **107/107 pass** locally
- \orge_capabilities\ and \	ools.json\ schema-sync tests both green
- Drift-proof checks intentionally green during \-dev\ cycles, fire only when VERSION goes clean without a matching CHANGELOG (release-tag invariant)

## Closes

- #155

## Companion fixes already on this branch (via slice-2/slice-3 + earlier work)

- tools.json \orge_run_plan\ description: restored \manualImport:true\ mention (bug #126 contract)
- github-introspect test: bumped check count 8→9 / 10→11 (Phase GITHUB-A added \copilot-coding-agent-assignable\)
- tools.json + capabilities.mjs \orge_tempering_drain\: cost medium→high, added \MISSING_PROJECTDIR\ + \MAX_ROUNDS_EXCEEDED\ errors, listed \drain-history.jsonl\ in produces
- tools.json + capabilities.mjs \orge_triage_route\: renamed \INVALID_FINDING\ → \MISSING_FINDING\ to match v2.80.0 contract