### PR TITLE
docs(manual): Phase-MANUAL-DISCOVERY-LOOP Phase 2 — complete slices 5-7

### DIFF
--- a/docs/manual/advanced-execution.html
+++ b/docs/manual/advanced-execution.html
@@ -355,6 +355,103 @@ score = clamp(1, 10, round(0.5425 × 9) + 1) = 6
 
       <p class="text-sm text-slate-400">📄 Cross-references: <a href="multi-agent.html">Chapter 12 — Multi-Agent</a> for the handoff model · <a href="remote-bridge.html#openclaw">Chapter 17 — Remote Bridge</a> for the OpenClaw snapshot path · <a href="forge-master.html#quorum-advisory">Forge-Master Quorum Advisory</a> for the per-prompt counterpart.</p>
 
+      <h3 id="quorum-quality-examples">Quorum Quality Examples — What 3 Models Catch That 1 Doesn't</h3>
+
+      <p>The argument for quorum mode is mostly abstract — "synthesis effect," "independent analyses," "reviewer picks the cleaner approach." A single side-by-side run of the same task makes the argument concrete. The numbers below come from a controlled A/B run on a real C# invoicing slice: same plan, same gates, same acceptance criteria; one execution with the default single-model worker, one with three-model quorum. <strong>Both passed all gates and the independent reviewer.</strong> The difference is in <em>how</em> they passed.</p>
+
+      <table>
+        <thead><tr><th>Metric</th><th>Single (control)</th><th>Quorum (3-model)</th></tr></thead>
+        <tbody>
+          <tr><td>Tests written</td><td>15</td><td><strong>18 (+20%)</strong></td></tr>
+          <tr><td>Helper extraction</td><td>Inline code, repeated 3×</td><td>Extracted helpers, single source</td></tr>
+          <tr><td>Test dates</td><td>Hardcoded literals</td><td>Relative offsets</td></tr>
+          <tr><td>.NET pattern</td><td>Generic <code>ValidationException</code></td><td><code>ArgumentException.ThrowIfNullOrWhiteSpace</code></td></tr>
+          <tr><td>Edge cases</td><td>Standard happy path</td><td>Voided invoice regen, sequence races</td></tr>
+          <tr><td>Total cost</td><td>$0.62</td><td>$0.84 (+35%)</td></tr>
+        </tbody>
+      </table>
+
+      <p>$0.22 of additional spend, both pass review, and the quorum run is measurably more maintainable. Four named patterns drive the difference.</p>
+
+      <h4>Pattern 1 — DRY helper extraction</h4>
+
+      <p>The single-model run inlined volume-discount math in three call sites with slight variations. The quorum run extracted reusable helpers because the synthesizer saw multiple proposals and picked the one that didn't repeat itself.</p>
+
+      <div class="callout callout-info">
+        <strong>Representative example.</strong> The quorum run produced <code>IsWeekend()</code>, <code>CalculateVolumeDiscount()</code>, and <code>ApplyBankersRounding()</code> as private static helpers, called from each invoicing entry point. The single-model run inlined the equivalent ternary expressions at every call site. Same behavior; different debuggability when the discount tier changes a year from now.</p>
+      </div>
+
+      <pre><code>// Single model — inlined at three call sites
+var discount = quantity &gt;= 100 ? 0.15m : quantity &gt;= 50 ? 0.10m : quantity &gt;= 10 ? 0.05m : 0m;
+
+// Quorum — extracted helper
+private static decimal CalculateVolumeDiscount(int quantity) =&gt; quantity switch
+{
+    &gt;= 100 =&gt; 0.15m,
+    &gt;= 50  =&gt; 0.10m,
+    &gt;= 10  =&gt; 0.05m,
+    _      =&gt; 0m,
+};</code></pre>
+
+      <h4>Pattern 2 — Robust test dates</h4>
+
+      <p>Single-model tests pinned dates to literal calendar days. Those tests will fail when those dates pass and the business logic correctly refuses future invoices. Quorum tests used relative offsets that stay green forever.</p>
+
+      <div class="callout callout-info">
+        <strong>Representative example.</strong> The control run wrote <code>new DateTime(2026, 3, 15)</code> in test fixtures. The quorum run wrote <code>DateTime.Now.AddDays(-7)</code>. Identical intent; only one survives March 16th.</p>
+      </div>
+
+      <pre><code>// Single model — breaks on April 16th
+var invoice = new Invoice { Date = new DateTime(2026, 3, 15) };
+
+// Quorum — stays green forever
+var invoice = new Invoice { Date = DateTime.Now.AddDays(-7) };</code></pre>
+
+      <h4>Pattern 3 — Modern .NET patterns</h4>
+
+      <p>Validation guard clauses are a tell. The control run used the generic exception path; the quorum run reached for the modern static-helper API that ships better error messages and is the current recommended pattern.</p>
+
+      <div class="callout callout-info">
+        <strong>Representative example.</strong> The control run used <code>throw new ValidationException("Customer name is required")</code>. The quorum run used <code>ArgumentException.ThrowIfNullOrWhiteSpace(customerName)</code>. The quorum reviewer chose the .NET 7+ helper because one of the three workers proposed it; the synthesizer recognized it as the modern equivalent.</p>
+      </div>
+
+      <pre><code>// Single model — generic, manual message
+if (string.IsNullOrWhiteSpace(customerName))
+    throw new ValidationException("Customer name is required");
+
+// Quorum — modern .NET 7+ helper, auto-generated message including parameter name
+ArgumentException.ThrowIfNullOrWhiteSpace(customerName);</code></pre>
+
+      <h4>Pattern 4 — Edge-case coverage the control missed entirely</h4>
+
+      <p>The +3 tests in the quorum run weren't padding. They were edge cases the single model never wrote because no one model considered both the happy path and the failure mode at the same time. With three independent analyses, edge cases that one model thinks of get surfaced into the synthesis.</p>
+
+      <div class="callout callout-info">
+        <strong>Representative example.</strong> The quorum run added a test for "regenerating an invoice after the original was voided" (<code>VoidedInvoice_Regenerate_AssignsNewSequenceNumber</code>) and a test for "concurrent invoice number assignment under two simultaneous requests" (<code>ConcurrentInvoiceCreation_DoesNotReuseSequenceNumbers</code>). Neither appeared in the control run. Both are exactly the kind of test that catches a production bug six weeks after launch.</p>
+      </div>
+
+      <h4>The synthesis mechanism</h4>
+
+      <p>The pattern across all four examples is the same: <strong>one model proposes one thing, another model proposes a cleaner version, the reviewer picks the cleaner one.</strong> Inline code vs extracted helper — extraction wins. Hardcoded date vs relative offset — relative offset wins. Generic exception vs modern helper — modern helper wins. Standard tests vs edge-case tests — edge-case tests win. The quorum doesn't make any individual model smarter; it makes the worst-case output of each model less likely to be what ships.</p>
+
+      <h4>When this pays off</h4>
+
+      <table>
+        <thead><tr><th>Slice type</th><th>Quorum worth it?</th><th>Why</th></tr></thead>
+        <tbody>
+          <tr><td>Auth / billing / payments</td><td><strong class="text-emerald-400">Yes</strong></td><td>Edge cases here are production bugs that cost money; +35% cost is cheap insurance</td></tr>
+          <tr><td>Database migrations</td><td><strong class="text-emerald-400">Yes</strong></td><td>Wrong migration is irreversible; multi-model agreement is a meaningful signal</td></tr>
+          <tr><td>Architectural slices (new layer, new pattern)</td><td><strong class="text-emerald-400">Yes</strong></td><td>The synthesis effect produces noticeably cleaner abstractions</td></tr>
+          <tr><td>Bug fix with tight reproducer</td><td><span class="text-amber-400">Maybe</span></td><td>If the fix is one line and the test is obvious, single model is fine</td></tr>
+          <tr><td>CRUD endpoint, well-trodden pattern</td><td><span class="text-rose-400">Probably not</span></td><td>All three models will produce nearly identical code; +35% cost buys nothing new</td></tr>
+          <tr><td>Pure docs slice</td><td><span class="text-rose-400">No</span></td><td>Synthesis effect doesn't apply to prose; pick the cheapest model that writes well</td></tr>
+        </tbody>
+      </table>
+
+      <p><code>--quorum=auto</code> applies this judgment per slice using the <a href="#quorum-complexity">complexity scoring rubric</a>. Manual <code>--quorum=power</code> and <code>--quorum=speed</code> let you force the call when you already know which slices are which. The <a href="audit-loop.html#discovery-harness">discovery harness</a> uses single-model dispatch by default because audit findings are mechanical; the auto-smelt loop is the place to catch defects, not the discovery pass.</p>
+
+      <p class="text-sm text-slate-400">📄 Source: <a href="../../blog/quorum-mode-3-models.html">Quorum Mode — What 3 Models Catch That 1 Doesn't</a> on the Plan Forge blog (the controlled A/B run that produced this comparison).</p>
+
       <h2 id="host-routing">Host-Aware Routing <span class="text-amber-400 text-base font-normal">v2.82+</span></h2>
       <p>Plan Forge runs in different IDEs and CLI hosts (VS Code + Copilot, Claude Code, Cursor, Windsurf, Zed, the bare CLI). Each host has its own billing surface. The host-aware routing preference (added v2.82, fixes #104) ensures users on non-Copilot hosts <strong>don't silently double-pay</strong> against subscriptions they're already paying for.</p>
 

--- a/docs/manual/assets/manual.js
+++ b/docs/manual/assets/manual.js
@@ -373,12 +373,16 @@
     { t: "Estimating Quorum Cost forge_estimate_quorum", u: "advanced-execution.html#quorum-estimate" },
     { t: "Quorum Complexity Scoring Rubric", u: "advanced-execution.html#quorum-complexity" },
     { t: "Multi-Agent Quorum Turns PFORGE_QUORUM_TURN", u: "advanced-execution.html#quorum-multi-agent" },
+    { t: "Quorum Quality Examples - 3 Models vs 1", u: "advanced-execution.html#quorum-quality-examples" },
     { t: "Host-Aware Routing", u: "advanced-execution.html#host-routing" },
     { t: "Cost Optimization", u: "advanced-execution.html#cost-optimization" },
     { t: "CI Integration GitHub Actions", u: "advanced-execution.html#ci-integration" },
     { t: "Parallel Execution DAG", u: "advanced-execution.html#parallel" },
     { t: "Resume and Retry", u: "advanced-execution.html#resume" },
     { t: "OpenBrain Memory", u: "advanced-execution.html#openbrain" },
+    // Audit Loop chapter
+    { t: "Discovery Harness Implementation", u: "audit-loop.html#discovery-harness" },
+    { t: "Three-Lane Triage Funnel", u: "audit-loop.html#three-lane-triage" },
     // Ch 14
     { t: "Diagnostic Tools", u: "troubleshooting.html#diagnostics" },
     { t: "Agent Not Following Guardrails", u: "troubleshooting.html#guardrails-not-loading" },

--- a/docs/manual/audit-loop.html
+++ b/docs/manual/audit-loop.html
@@ -142,6 +142,43 @@ pforge audit-loop --env=staging</code></pre>
           <strong>Further reading.</strong> For a real-world walkthrough of the 4-pass sequence applied to a production Next.js site, see the blog post <a href="../../blog/the-loop-that-never-ends.html">The Loop That Never Ends</a>.
         </div>
 
+        <h2 id="three-lane-triage">Three-Lane Triage Funnel</h2>
+        <p>Every finding from the discovery harness gets sorted into one of three lanes by the wrapper before reaching Crucible. Lane assignment determines whether a human ever sees the finding, what shape the resulting plan slice takes, and how the loop closes. The funnel is the difference between an audit that produces 100 PRs nobody reads and an audit that produces 5 PRs that ship.</p>
+
+        <img src="assets/diagrams/triage-three-lane-funnel.svg" alt="Three-Lane Triage Funnel: discovery findings sorted into Bug Lane (auto-smelt to bug-registry), Spec Lane (escalate to human spec author), and Classifier Lane (refine the classifier itself when uncertain)" class="diagram-img diagram-img-md my-4" />
+
+        <h3 id="bug-lane">Bug Lane — Auto-smelt to Bug Registry</h3>
+        <p>Findings with high confidence and a clear remediation pattern (broken links, non-200 status codes, placeholder markers, hydration failures) drop into the bug lane. The wrapper packages them as Crucible smelts with severity attached, then the auto-smelt pass converts them into entries in the <a href="bug-registry.html">bug registry</a>. No human triage required — the loop closes automatically.</p>
+        <p>Representative example: a 4-pass run finds 8 broken anchor links across the docs. All 8 land in the bug lane as a single batch smelt with severity <code>medium</code>, generate one plan slice that fixes them together, and close themselves out via tempering re-audit.</p>
+
+        <h3 id="spec-lane">Spec Lane — Escalate to Human Spec Author</h3>
+        <p>Findings that imply missing or ambiguous spec content (placeholder headings like "Coming soon," pages with zero meaningful content, hydrated SPAs that crash without JS) drop into the spec lane. These can't be auto-fixed because the harness doesn't know what content <em>should</em> be there — only that something is missing. The wrapper escalates them as <a href="crucible.html">Crucible</a> smelts requiring human input before they can be hardened into plan slices.</p>
+        <p>Representative example: the harness finds a route titled "Pricing — Coming soon" with 12 words of body content. Spec lane escalates this to a human as a Crucible smelt requesting a draft of the actual pricing tier copy. The human responds in the Crucible interview funnel, the wrapper hardens the response into a plan slice, and the loop resumes.</p>
+
+        <h3 id="classifier-lane">Classifier Lane — Refine the Classifier</h3>
+        <p>Findings the classifier can't confidently sort (novel signals, contradictory evidence, low confidence scores) drop into the classifier lane. Rather than guess, the wrapper records the finding plus the classifier's confusion signal as a Crucible smelt targeting the classifier itself. Over time, classifier-lane volume should drop as the classifier learns from each handoff.</p>
+        <p>Representative example: the harness finds a 200 OK route with full content but the document title is just <code>"."</code> — the classifier hasn't seen this signal before. Classifier lane creates a smelt asking the maintainer "should pages with single-character titles be flagged as defective?" The answer becomes a new classifier rule for the next run.</p>
+
+        <h3>Finding-type to lane mapping</h3>
+        <table>
+          <thead><tr><th>Finding type</th><th>Default lane</th><th>Why</th></tr></thead>
+          <tbody>
+            <tr><td>Non-200 HTTP status</td><td>Bug</td><td>Unambiguous failure, fix is mechanical</td></tr>
+            <tr><td>Broken anchor / link</td><td>Bug</td><td>Target either exists or it doesn't; trivial to verify</td></tr>
+            <tr><td>Placeholder marker (TODO, Coming soon)</td><td>Spec</td><td>Implies missing content, not broken content</td></tr>
+            <tr><td>Zero meaningful content</td><td>Spec</td><td>Page exists but says nothing — needs human authoring</td></tr>
+            <tr><td>Hydration failure (SPA crashes without JS)</td><td>Bug</td><td>Build / config defect, not a content gap</td></tr>
+            <tr><td>Novel signal / low confidence</td><td>Classifier</td><td>Classifier can't sort; ask the maintainer</td></tr>
+            <tr><td>Mixed signals (multiple conflicting findings)</td><td>Classifier</td><td>Pre-empt a wrong auto-smelt by asking first</td></tr>
+          </tbody>
+        </table>
+
+        <div class="callout callout-info">
+          <strong>What gets auto-smelted.</strong> Only the bug lane runs autonomously. Spec and classifier lanes always require a human in the loop — by design. The point of the funnel is to keep humans focused on <em>what only humans can answer</em> (intent, scope, novel signals), not on triaging mechanical defects the harness already understands.
+        </div>
+
+        <p>For a worked example of how the bug lane closes a real defect end-to-end, including the multi-model quality patterns that catch issues a single model misses, see <a href="advanced-execution.html#quorum-quality-examples">Quorum Quality Examples</a> in Chapter 13.</p>
+
         <h2>Design Decisions</h2>
         <ul>
           <li><strong>Classifier proposals are local files</strong> (v2.80): Written to <code>.forge/audits/</code> as JSON artifacts. GitHub PR creation deferred to v2.81+.</li>


### PR DESCRIPTION
## Summary

Completes Phase-MANUAL-DISCOVERY-LOOP slices 5–7 manually after the orchestrator's first-pass run hit two defects on slices 5 and 6 (filed as issue #162).

Slices 1–4 already on master from the orchestrator's clean partial run + parallel session integration. This PR adds the missing 3 slices via direct agent execution, matching the hardened plan word-for-word and passing all validation gates.

---

## What landed

### Slice 5 — Three-Lane Triage Funnel section in `audit-loop.html`

- New `<h2 id="three-lane-triage">` section inserted between Discovery Harness Implementation and Design Decisions
- Embeds `triage-three-lane-funnel.svg` (already on master from Phase 1)
- 3 sub-sections (`#bug-lane`, `#spec-lane`, `#classifier-lane`) — each with a "Representative example" callout grounding the explanation in a concrete finding
- Finding-type → lane mapping table (7 rows: non-200, broken link, placeholder, zero-content, hydration failure, novel signal, mixed signals)
- "What gets auto-smelted" callout
- Cross-links to `bug-registry.html`, `crucible.html`, and `advanced-execution.html#quorum-quality-examples`

### Slice 6 — Quorum Quality Examples section in `advanced-execution.html`

- New `<h3 id="quorum-quality-examples">` inserted **immediately before** `<h2 id="host-routing">`. Anchor ordering verified: `#quorum-multi-agent` < `#quorum-quality-examples` < `#host-routing`.
- Opens with the 18 vs 15 tests headline + comparison table from the source blog A/B run
- 4 named patterns, each with a "Representative example" callout and a C# snippet contrasting single-model vs quorum:
  - DRY helper extraction (`IsWeekend()`, `CalculateVolumeDiscount()`, `ApplyBankersRounding()`)
  - Robust test dates (`DateTime.Now.AddDays(-7)` vs hardcoded literals)
  - Modern .NET patterns (`ArgumentException.ThrowIfNullOrWhiteSpace` vs generic `ValidationException`)
  - Edge-case coverage (`VoidedInvoice_Regenerate_AssignsNewSequenceNumber`, concurrent sequence races)
- Synthesis mechanism callout — explains the "one model proposes, another proposes cleaner, reviewer picks cleaner" pattern
- "When this pays off" decision table (6 rows: auth/billing yes, migrations yes, architecture yes, bug fix maybe, CRUD probably-not, docs no)
- Cross-links to `audit-loop.html#discovery-harness` and `advanced-execution.html#quorum-complexity`
- Source link back to the blog post

### Slice 7 — Search anchors in `manual.js`

3 new `SEARCH_SECTIONS` entries for cross-page search:
- `Quorum Quality Examples - 3 Models vs 1` → `advanced-execution.html#quorum-quality-examples`
- `Discovery Harness Implementation` → `audit-loop.html#discovery-harness`
- `Three-Lane Triage Funnel` → `audit-loop.html#three-lane-triage`

---

## Verification

| Gate | Result |
|---|---|
| Slice 5 gate (10 checks: anchor, SVG embed, 3 sub-sections, 3 cross-links, preserved sections) | **10/10 pass** |
| Slice 6 gate (11 checks: anchor, 5 keyword presence, blog link, 4+ Representative example callouts, anchor ordering, 2 cross-links) | **11/11 pass** |
| Slice 7 gate (`node --check` + 3 anchors present) | **clean** |
| Both SVGs verified on disk | ✅ |
| `scripts/check-metrics.ps1 -Strict` | `[OK] No stale metric aliases found.` |
| `git diff --stat` shows changes only in `docs/manual/` | ✅ |
| `costForLeg()` byte-identical | ✅ (no code touched) |

---

## Why agent execution

The orchestrator's first run on this plan (`2026-05-07T00-28-30-053Z_Phase-MANUAL-DISCOVERY-LOOP-PLAN`) shipped slices 1–4 cleanly, but slices 5 and 6 hit two distinct defects now tracked in [#162](https://github.com/srnichols/plan-forge/issues/162):

1. **Auto-commit quote escaping** — slice 5 title `Add "Three-Lane Triage Funnel" section to audit-loop.html` broke the orchestrator's `git commit -m` shell construction (unescaped inner quotes interpreted as path arguments). Slice 5's edits ended up in a `pforge-slice-5-snapshot` stash mixed with foreign files.
2. **Probe regression mid-run** — slice 6 hit "No CLI workers available" despite `gh copilot --version` working at the shell. Issue #159's fix doesn't address this regression class.

Rather than re-run the orchestrator and risk hitting both defects again on the same slices, completing 5–7 directly as agent was the cleaner path. Same end state, no orchestrator-quirk dependency.

---

## Cost

$0 incremental — agent tokens, no orchestrator dispatch. The original Phase 1 partial run cost $0.09 (subscription path; v2.83.0 + Phase-COST-TOKEN-COVERAGE math working as designed against a $15.08 token-rate estimate).

---

## Provenance

- Original plan: [`docs/plans/Phase-MANUAL-DISCOVERY-LOOP-PLAN.md`](docs/plans/Phase-MANUAL-DISCOVERY-LOOP-PLAN.md)
- Phase 1 commits already on master (slices 1–4): `330d320`, `3c69742`, `9954286`
- Phase 2 (this PR): `1189701`
- Defects observed during orchestrator run: [#162](https://github.com/srnichols/plan-forge/issues/162)