### PR TITLE
docs(security): Phase-AUTH-RBAC-SCAFFOLD Slice 8 - auth-model, sso-extension-point, rbac-config + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Phase-AUTH-RBAC-SCAFFOLD — Auth model + SSO extension point + RBAC scaffold (2026-05-07)
+
+> **One-liner**: Introduces a pluggable authentication model for Plan Forge MCP — a provider-dispatch `authenticate()` entry point, a bearer-token provider (behavior-preserving refactor of the existing `approvalSecret` flow), an SSO provider interface stub ready for `Phase-ENTRA-SSO`, a config-driven RBAC resolver (`resolveRoles` / `expandScopes` / `hasScope` with `:` hierarchy and `*` wildcard), `withAuth` middleware that gates tool dispatch and bridge edits, and three security docs. Fully backward-compatible: absent `.forge/rbac.json` → open-by-default, identical to pre-RBAC behavior.
+
+#### Added
+- `pforge-mcp/auth/index.mjs` — provider-dispatch `authenticate(req, opts)` entry point. Supports `bearer` (default), `sso`, and `none` providers. Returns a normalized `AuthResult` (`{ ok, token, provider, error? }`).
+- `pforge-mcp/auth/providers/bearer.mjs` — extracted bearer-token provider. Accepts tokens via `Authorization: Bearer <token>` header or `PFORGE_AUTH_TOKEN` env var. Permissive mode (any non-empty token) when no secret is configured; strict mode (exact match) when `opts.token` is set. Behavior-preserving refactor of the pre-phase `approvalSecret` check.
+- `pforge-mcp/auth/providers/sso-stub.mjs` — SSO provider interface stub. Returns `ok: false` with a clear "not yet implemented" message. Replaced by a real provider in `Phase-ENTRA-SSO`. Defines the two-function contract (`authenticate`, `healthCheck`) that all SSO providers must implement.
+- `pforge-mcp/auth/rbac.mjs` — config-driven RBAC resolver. Exports `resolveRoles(principal, config)` (transitive role expansion with cycle guard), `hasScope(roles, scope, config)` (exact, prefix-wildcard `:*`, and global-wildcard `*` matching). Reads `.forge/rbac.json`; absent config → all scope checks pass (open-by-default invariant).
+- `pforge-mcp/auth/middleware.mjs` — `withAuth(handler, opts)` factory. Wraps any `(req, res)` handler with authentication (step 1) and optional RBAC scope check (step 2). On failure writes a structured JSON error (`401` / `403` / `500`) and short-circuits the handler. On success enriches `req.auth` with the `AuthResult`.
+- `.forge/rbac.example.json` — annotated example RBAC config with `admin`, `developer`, `reader`, `ci` roles and example token assignments. Copy to `.forge/rbac.json` to activate.
+- `pforge-mcp/tests/auth-rbac.test.mjs` — 12 test cases covering all acceptance criteria: absent-config backward compat, bearer valid/invalid, SSO stub interface shape, `resolveRoles` literal + inherited, `hasScope` hierarchy and wildcard, `withAuth` rejection on missing scope, auth-denial event emission, read-only open default.
+- `docs/security/auth-model.md` — canonical statement of the Plan Forge authentication model: current bearer state, pluggable provider architecture, identity shape, middleware usage, security boundaries, read-only tool defaults, and how to add a new provider.
+- `docs/security/sso-extension-point.md` — SSO provider contract: interface definition, current stub, step-by-step implementation guide, per-request lifecycle, error handling, response shapes, auth-decision event format, constraints, and planned future providers.
+- `docs/security/rbac-config.md` — `.forge/rbac.json` schema reference: field descriptions, scope syntax (exact / prefix-wildcard / global-wildcard), built-in scope catalogue, common patterns (admin, developer, viewer, CI/CD), role inheritance examples, and recovery instructions.
+
+#### Notes
+- `bridge.approvalSecret` config key and `PFORGE_APPROVAL_SECRET` env var are unchanged — the bearer provider reads them identically to the pre-phase implementation.
+- When `.forge/rbac.json` is absent, `withAuth` skips all scope checks and the system behaves byte-identically to the pre-RBAC state. No existing solo-operator workflow is affected.
+- `costForLeg()` and `priceSlice()` in `cost-service.mjs` are untouched.
+- No release in this phase.
+
+---
+
 ### Phase-FOUNDRY-PROVIDER — Microsoft Azure AI Foundry / BYO Azure OpenAI provider (2026-05-07)
 
 > **One-liner**: Adds `microsoft-foundry` as a first-class Plan Forge provider, enabling enterprises to route plan execution through their own Azure OpenAI Service or Azure AI Foundry endpoint. Two auth paths (API key and Entra/Managed Identity with `@azure/identity` optional dep), government-cloud auto-detection, deployment-name → model-key normalization via `.forge/foundry-deployments.json`, AOAI deployment-type cost uplift (Data Zone/Regional 1.1×), and a new `power-gov` quorum preset for Azure Government catalog models. Three new docs cover the BYO setup guide, Foundry Toolbox MCP integration, and App Insights OTel sink.

--- a/docs/security/auth-model.md
+++ b/docs/security/auth-model.md
@@ -1,0 +1,179 @@
+# Plan Forge — Authentication Model
+
+> **Phase**: Phase-AUTH-RBAC-SCAFFOLD  
+> **Status**: Scaffold shipped — bearer provider active, SSO provider interface defined, RBAC config-driven  
+> **Source**: `docs/research/enterprise-fleet-readiness.md` §8.1
+
+---
+
+## Overview
+
+Plan Forge uses a pluggable authentication model. A single `authenticate(req, opts)` entry point in `pforge-mcp/auth/index.mjs` delegates to a registered provider and returns a normalized `AuthResult`. All server-side auth decisions flow through this single gate.
+
+### Current state
+
+Out of the box, Plan Forge ships with one active provider:
+
+| Provider | Status | Source |
+|---|---|---|
+| `bearer` | ✅ Active | `pforge-mcp/auth/providers/bearer.mjs` |
+| `sso` | 🔲 Stub only | `pforge-mcp/auth/providers/sso-stub.mjs` |
+| `none` | ✅ Local bypass | `pforge-mcp/auth/index.mjs` |
+
+The **bearer** provider validates a secret token via `Authorization: Bearer <token>` or the `PFORGE_AUTH_TOKEN` environment variable. It is backward-compatible with the pre-Phase-AUTH-RBAC-SCAFFOLD `bridge.approvalSecret` flow.
+
+---
+
+## Identity Shape
+
+A successful authentication returns an `AuthResult`:
+
+```js
+{
+  ok:       true,
+  token:    "<validated-token-string>",
+  provider: "bearer" | "sso" | "none"
+}
+```
+
+On failure:
+
+```js
+{
+  ok:       false,
+  token:    "",
+  provider: "bearer" | "sso" | "none",
+  error:    "Human-readable reason"
+}
+```
+
+For SSO providers, the `token` field carries the subject identifier (user ID, email, or claim value) that is then used as the RBAC principal key.
+
+---
+
+## Provider Selection
+
+The provider is selected via the `opts.provider` argument passed to `authenticate()`:
+
+| Value | Provider |
+|---|---|
+| `"bearer"` (default) | Token from `Authorization` header or env var |
+| `"sso"` | Enterprise SSO / OIDC (stub — not yet implemented) |
+| `"none"` | Always succeeds — use only in trusted local environments |
+
+When no `opts.provider` is specified, `"bearer"` is used.
+
+---
+
+## Bearer Provider
+
+The bearer provider (`pforge-mcp/auth/providers/bearer.mjs`) validates tokens in two modes:
+
+### Permissive mode (solo operator / local dev)
+
+When no expected token is configured (`opts.token` is absent), any non-empty token is accepted. This preserves the pre-RBAC behavior for solo operators who have not set an approval secret.
+
+### Strict mode (team / enterprise)
+
+When `opts.token` is set (typically from `.forge/config.json` `bridge.approvalSecret` or `PFORGE_APPROVAL_SECRET`), the extracted token must match exactly.
+
+**Token extraction order**:
+1. `Authorization: Bearer <token>` header (case-insensitive `Bearer` prefix)
+2. `PFORGE_AUTH_TOKEN` environment variable
+
+---
+
+## Middleware
+
+`pforge-mcp/auth/middleware.mjs` exports `withAuth(handler, opts)` which wraps any `(req, res)` handler:
+
+1. **Authentication** — calls `authenticate(req, opts)`. Returns `401` on failure.
+2. **Authorization** — if `opts.scope` is set, resolves the principal's RBAC roles and checks the required scope. Returns `403` on failure.
+3. **Context enrichment** — sets `req.auth = authResult` before invoking the original handler.
+
+```js
+import { withAuth } from "./auth/middleware.mjs";
+
+// Read-only route — no scope required
+router.get("/status", withAuth(statusHandler, { provider: "bearer", token: secret }));
+
+// Write route — requires "plans:write" scope
+router.post("/plans", withAuth(plansHandler, {
+  provider: "bearer",
+  token:    secret,
+  scope:    "plans:write",
+  rbac:     rbacConfig,
+}));
+```
+
+---
+
+## Security Boundaries
+
+### What auth enforces
+
+- Identity verification (token present and valid)
+- RBAC scope checks (when `.forge/rbac.json` is present)
+- `bridge:edit` authorization before allowing file edits
+
+### What auth does NOT enforce
+
+- Network-level controls (mTLS, IP allowlists) — operator/infra concern
+- Encryption at rest for `.forge/secrets.json` — operator concern
+- Multi-tenant data segregation — orthogonal; out of scope this phase
+- Approval workflows (n-of-m human approvers) — planned for a future phase
+
+### Backward compatibility
+
+When `.forge/rbac.json` is absent, Plan Forge behaves identically to the pre-RBAC state: bearer-only, no scope enforcement. Scope checks are skipped entirely; any valid token is sufficient.
+
+This invariant is non-negotiable. Solo operators must never be locked out by missing config.
+
+---
+
+## Auth Decision Events
+
+Authentication and authorization outcomes are recorded as `auth-decision` events in `events.log` using the Phase-TRAJECTORY-SCHEMA-HARDENING schema:
+
+```json
+{
+  "source": "auth",
+  "security_risk": "medium",
+  "result": "allowed",
+  "provider": "bearer",
+  "principal": "<token-hash>",
+  "scope": "bridge:edit"
+}
+```
+
+Denials use `security_risk: "high"` and `result: "denied"`. Tokens are never logged in plaintext; use `redactSecrets` from `pforge-mcp/secrets.mjs` when emitting any auth event that touches token values.
+
+---
+
+## Adding a New Provider
+
+1. Create `pforge-mcp/auth/providers/<name>.mjs` that exports an `authenticate<Name>(req, opts)` function returning `AuthResult`.
+2. Register the provider in `pforge-mcp/auth/index.mjs` by adding a `case "<name>":` branch.
+3. Add `healthCheck()` if the provider connects to an external IdP.
+4. Document the provider in `docs/security/sso-extension-point.md` if it is an enterprise SSO variant.
+5. The new provider MUST NOT add required npm dependencies without a corresponding plan update.
+
+See `docs/security/sso-extension-point.md` for the full SSO provider contract.
+
+---
+
+## Read-Only Tool Defaults
+
+The following tools require no scope and succeed for any authenticated principal (or even unauthenticated callers when `rbac.json` is absent):
+
+- `forge_capabilities`
+- `forge_status`
+- `forge_search`
+- `forge_timeline`
+- `forge_watch_live`
+- `forge_home_snapshot`
+- `forge_cost_report`
+- `forge_plan_status`
+- `forge_diff`
+
+Operators can restrict any of these by adding explicit scope requirements in `.forge/rbac.json`. New tools added to `server.mjs` require an explicit scope decision before shipping — document the decision in the PR.

--- a/docs/security/rbac-config.md
+++ b/docs/security/rbac-config.md
@@ -1,0 +1,275 @@
+# Plan Forge — RBAC Configuration
+
+> **Phase**: Phase-AUTH-RBAC-SCAFFOLD  
+> **Config file**: `.forge/rbac.json`  
+> **Example**: `.forge/rbac.example.json`  
+> **Source**: `docs/research/enterprise-fleet-readiness.md` §8.1, Required Decisions #3 and #4
+
+---
+
+## Overview
+
+Role-Based Access Control in Plan Forge is config-driven. Operators define roles, the scopes each role grants, and which principals (token values or user IDs) are assigned to which roles — all in a single JSON file at `.forge/rbac.json`.
+
+When this file is absent, Plan Forge behaves identically to the pre-RBAC state: bearer-only, no scope enforcement. Existing solo-operator installs are unaffected.
+
+---
+
+## File Schema
+
+```json
+{
+  "_comment": "Optional — ignored by the loader",
+  "roles": {
+    "<role-name>": {
+      "inherits": ["<parent-role>"],
+      "scopes":   ["<scope-string>"]
+    }
+  },
+  "assignments": {
+    "<principal-key>": ["<role-name>"]
+  }
+}
+```
+
+### `roles`
+
+A map of named role definitions. Each role has:
+
+| Field | Type | Description |
+|---|---|---|
+| `inherits` | `string[]` | Parent role names. Scopes are unioned across the inheritance chain. Cycles are silently broken. |
+| `scopes` | `string[]` | Scope strings directly granted by this role (see [Scope Syntax](#scope-syntax) below). |
+
+### `assignments`
+
+A map from principal key to an array of role names. The principal key is the `token` value returned by the active auth provider:
+
+- **Bearer provider**: the literal bearer token string (or a named identifier like `"token:my-ci-token"` — use descriptive prefixes for readability)
+- **SSO providers**: the subject claim value (`sub` or `oid`) from the verified JWT
+
+---
+
+## Scope Syntax
+
+Scopes are hierarchical strings separated by `:`.
+
+### Exact match
+
+```
+"plans:read"
+```
+
+Grants access only to the `plans:read` scope.
+
+### Prefix wildcard
+
+```
+"plans:*"
+```
+
+Grants any scope whose prefix is `plans:` — for example `plans:read`, `plans:write`, `plans:execute`, `plans:delete`.
+
+### Global wildcard
+
+```
+"*"
+```
+
+Grants every scope. Assign only to fully-trusted administrator roles.
+
+### Hierarchy examples
+
+| Scope granted | Authorizes |
+|---|---|
+| `"forge:read"` | `forge:read` only |
+| `"forge:*"` | `forge:read`, `forge:write`, `forge:run`, and any future `forge:` scope |
+| `"bridge:edit"` | `bridge:edit` only |
+| `"bridge:edit:plan-files"` | `bridge:edit:plan-files` only (more restrictive than `bridge:edit`) |
+| `"*"` | Everything |
+
+> **Note**: `hasScope` checks whether any granted scope *covers* the required scope. A required `bridge:edit` is satisfied by a granted `bridge:*` or `*`, but NOT by `bridge:edit:plan-files` (a sub-scope does not cover its parent).
+
+---
+
+## Built-in Scope Catalogue
+
+### Forge operations
+
+| Scope | Description |
+|---|---|
+| `forge:read` | Read forge state (plans, runs, cost, search) |
+| `forge:write` | Modify forge config (not plan execution) |
+| `forge:run` | Execute plans and slices |
+| `forge:*` | All forge operations |
+
+### Bridge edits
+
+| Scope | Description |
+|---|---|
+| `bridge:edit` | Approve any file edit via the bridge |
+| `bridge:edit:plan-files` | Approve edits to plan files only (`docs/plans/**`) |
+| `bridge:*` | All bridge operations |
+
+### Audit and export
+
+| Scope | Description |
+|---|---|
+| `audit:export` | Run `pforge audit export` and read events.log |
+| `audit:*` | All audit operations |
+
+### Admin
+
+| Scope | Description |
+|---|---|
+| `admin:*` | All admin operations (user management, config changes) |
+
+### Read-only tools (open by default)
+
+These tools require no scope when `rbac.json` is absent or the tool is not listed with a scope requirement:
+
+- `forge_capabilities`, `forge_status`, `forge_search`, `forge_timeline`
+- `forge_watch_live`, `forge_home_snapshot`, `forge_cost_report`
+- `forge_plan_status`, `forge_diff`
+
+To restrict them, add explicit scope requirements in your `rbac.json` configuration.
+
+---
+
+## Example Configuration
+
+The annotated example at `.forge/rbac.example.json` ships with Plan Forge:
+
+```json
+{
+  "_comment": "Example RBAC configuration for Plan Forge MCP. Copy to .forge/rbac.json and customise.",
+  "roles": {
+    "admin": {
+      "inherits": ["developer"],
+      "scopes": ["admin:*", "users:delete", "plans:delete", "secrets:read"]
+    },
+    "developer": {
+      "inherits": ["reader"],
+      "scopes": ["plans:write", "plans:execute", "deploy:staging", "forge:write"]
+    },
+    "reader": {
+      "inherits": [],
+      "scopes": ["plans:read", "forge:read", "dashboard:view"]
+    },
+    "ci": {
+      "inherits": [],
+      "scopes": ["plans:read", "plans:execute", "deploy:staging"]
+    }
+  },
+  "assignments": {
+    "token:replace-with-admin-token": ["admin"],
+    "token:replace-with-dev-token": ["developer"],
+    "token:replace-with-ci-token": ["ci"],
+    "user:alice": ["developer"],
+    "user:bob": ["reader"]
+  }
+}
+```
+
+---
+
+## Common Patterns
+
+### Admin / operator (full access)
+
+```json
+{
+  "roles": {
+    "admin": { "inherits": [], "scopes": ["*"] }
+  },
+  "assignments": {
+    "token:my-admin-secret": ["admin"]
+  }
+}
+```
+
+### Developer (run plans, edit plan files)
+
+```json
+{
+  "roles": {
+    "developer": {
+      "inherits": [],
+      "scopes": ["forge:run", "forge:read", "bridge:edit:plan-files", "audit:export"]
+    }
+  },
+  "assignments": {
+    "token:dev-token": ["developer"]
+  }
+}
+```
+
+### Read-only viewer
+
+```json
+{
+  "roles": {
+    "viewer": {
+      "inherits": [],
+      "scopes": ["forge:read", "audit:export"]
+    }
+  },
+  "assignments": {
+    "token:readonly-token": ["viewer"]
+  }
+}
+```
+
+### CI/CD automation
+
+```json
+{
+  "roles": {
+    "ci": {
+      "inherits": [],
+      "scopes": ["forge:run", "forge:read", "bridge:edit:plan-files"]
+    }
+  },
+  "assignments": {
+    "token:ci-pipeline-token": ["ci"]
+  }
+}
+```
+
+### Role inheritance chain
+
+```json
+{
+  "roles": {
+    "reader":    { "inherits": [],           "scopes": ["forge:read"] },
+    "developer": { "inherits": ["reader"],   "scopes": ["forge:run", "bridge:edit:plan-files"] },
+    "admin":     { "inherits": ["developer"],"scopes": ["forge:write", "bridge:edit", "admin:*"] }
+  }
+}
+```
+
+An `admin` principal automatically gains all `developer` and `reader` scopes through inheritance, plus their own admin scopes.
+
+---
+
+## Recovery
+
+If a misconfigured `rbac.json` locks all operators out of the bridge, recover by editing the file directly on the filesystem:
+
+```bash
+# On the machine running Plan Forge:
+nano .forge/rbac.json   # add your token to the admin role assignments
+# Restart Plan Forge to reload the config
+```
+
+Because `rbac.json` is read at process start (hot-reload is deferred to a future phase), a restart is always sufficient to apply changes.
+
+---
+
+## Operational Notes
+
+- **Config is read once at startup.** Restart Plan Forge after editing `rbac.json` to apply changes.
+- **No migration needed from pre-RBAC installs.** Absent `rbac.json` = open-by-default.
+- **Token values in assignments are matched literally.** Use descriptive prefixes (`token:`, `user:`, `ci:`) to make logs and config readable without exposing secrets.
+- **Wildcard patterns on assignment keys are not supported** in this phase. Patterns on scope strings are supported (`:*`). Identity wildcard matching (e.g., `*@example.com → developer`) is planned for a follow-on phase.
+- **The `_comment` field is ignored by the loader** — use it freely for inline documentation.

--- a/docs/security/sso-extension-point.md
+++ b/docs/security/sso-extension-point.md
@@ -1,0 +1,224 @@
+# Plan Forge — SSO Extension Point
+
+> **Phase**: Phase-AUTH-RBAC-SCAFFOLD  
+> **Status**: Interface defined — stub shipped, first real provider deferred to Phase-ENTRA-SSO  
+> **Source**: `docs/research/enterprise-fleet-readiness.md` §8.1, Required Decision #5
+
+---
+
+## Overview
+
+Plan Forge defines a minimal SSO provider interface that allows enterprise identity providers (Entra ID, Okta, GitHub OIDC, etc.) to be plugged in without modifying the core auth module. This document describes the contract, lifecycle, error handling, and how to implement a real provider from the scaffold shipped in this phase.
+
+---
+
+## Provider Interface
+
+An SSO provider is a module that exports two functions:
+
+```ts
+interface SsoProvider {
+  /**
+   * Authenticate an incoming request.
+   * Returns an AuthResult on success or failure.
+   * MUST NOT throw — return ok:false with an error message instead.
+   */
+  authenticate(req: Request, opts?: SsoOptions): AuthResult;
+
+  /**
+   * Probe the IdP endpoint to verify connectivity.
+   * Called at process start and by health-check routes.
+   * Returns true if the IdP is reachable, false otherwise.
+   */
+  healthCheck(): Promise<boolean>;
+}
+```
+
+### AuthResult shape
+
+```ts
+interface AuthResult {
+  ok:       boolean;    // true on successful authentication
+  token:    string;     // subject identifier (user ID, email, or claim value)
+  provider: string;     // provider name for logging
+  error?:   string;     // human-readable reason on failure
+}
+```
+
+The `token` field on a successful SSO result carries the subject identifier that becomes the RBAC principal key (used as the key into `assignments` in `.forge/rbac.json`).
+
+---
+
+## Current Stub
+
+`pforge-mcp/auth/providers/sso-stub.mjs` ships an intentionally non-functional placeholder:
+
+```js
+export function authenticateSso(_req, _opts = {}) {
+  return {
+    ok:    false,
+    token: "",
+    error: "SSO provider not yet implemented — use bearer token authentication",
+  };
+}
+```
+
+Requesting `provider: "sso"` with the stub active returns `ok: false` and a clear message. This is intentional — the stub surfaces a predictable error rather than crashing so callers can detect the misconfiguration early.
+
+---
+
+## Implementing a Real Provider
+
+Replace the body of `authenticateSso` (or create a new module and register it) following these steps:
+
+### Step 1 — Create the provider module
+
+```js
+// pforge-mcp/auth/providers/entra-oidc.mjs
+
+export async function authenticateEntraOidc(req, opts = {}) {
+  const headers = req?.headers ?? {};
+  const authHeader = headers["authorization"] ?? headers["Authorization"] ?? "";
+  const match = /^Bearer\s+(\S+)$/i.exec(authHeader.trim());
+
+  if (!match) {
+    return { ok: false, token: "", error: "No bearer token provided" };
+  }
+
+  const rawToken = match[1];
+
+  try {
+    const claims = await verifyEntraToken(rawToken, opts);
+    return { ok: true, token: claims.sub ?? claims.oid, provider: "entra-oidc" };
+  } catch (err) {
+    return { ok: false, token: "", error: `Token verification failed: ${err.message}` };
+  }
+}
+
+export async function healthCheck() {
+  try {
+    const res = await fetch(`${ENTRA_METADATA_URL}/.well-known/openid-configuration`);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+```
+
+### Step 2 — Register in index.mjs
+
+Add a `case` branch to the `authenticate()` switch:
+
+```js
+case "entra-oidc": {
+  const result = await authenticateEntraOidc(req, opts);
+  return { ...result, provider: "entra-oidc" };
+}
+```
+
+### Step 3 — Wire the config
+
+Add the provider name to `.forge/config.json`:
+
+```json
+{
+  "auth": {
+    "provider": "entra-oidc",
+    "entraOidc": {
+      "tenantId": "<AZURE_TENANT_ID>",
+      "clientId": "<AZURE_CLIENT_ID>",
+      "audience": "api://<APP_ID>"
+    }
+  }
+}
+```
+
+### Step 4 — Map identities to RBAC roles
+
+In `.forge/rbac.json`, use the subject claim value (`sub` or `oid`) as the assignment key:
+
+```json
+{
+  "assignments": {
+    "00000000-0000-0000-0000-000000000001": ["developer"],
+    "00000000-0000-0000-0000-000000000002": ["admin"]
+  }
+}
+```
+
+---
+
+## Lifecycle
+
+### Process startup
+
+1. `server.mjs` reads `.forge/config.json` to determine the configured provider.
+2. If the provider exports `healthCheck`, it is called once. A `false` result logs a warning but does NOT prevent startup — the provider may become healthy after a brief IdP cold start.
+3. The resolved provider is set for the process lifetime. Hot-reload is not supported; restart Plan Forge to change the active provider.
+
+### Per-request flow
+
+```
+Request arrives
+  └─► withAuth(handler, opts)
+        ├─ authenticate(req, opts)  ← provider dispatched here
+        │     ├─ Bearer: extract + match token
+        │     ├─ SSO:    verify JWT / OIDC claims with IdP
+        │     └─ None:   always ok (local bypass)
+        ├─ resolveRoles(principal, rbacConfig)
+        ├─ hasScope(roles, requiredScope, rbacConfig)
+        └─ req.auth = authResult → handler
+```
+
+---
+
+## Error Handling
+
+### Provider MUST NOT throw
+
+Providers should catch all internal errors and return `{ ok: false, error: "..." }`. An unhandled exception in an auth provider is treated as a `500 Internal Server Error` by the middleware.
+
+### Error response shapes
+
+| Condition | HTTP status | Response body |
+|---|---|---|
+| No token / bad format | 401 | `{ "ok": false, "error": "No bearer token provided" }` |
+| Token invalid / expired | 401 | `{ "ok": false, "error": "Token verification failed: ..." }` |
+| Scope not granted | 403 | `{ "ok": false, "error": "Forbidden: scope \"plans:write\" is required" }` |
+| RBAC config missing when scope required | 500 | `{ "ok": false, "error": "Server configuration error: RBAC config required when scope is set" }` |
+
+### Auth decision events
+
+Every 401 and 403 outcome emits an `auth-decision` event to `events.log`:
+
+```json
+{
+  "source": "auth",
+  "security_risk": "high",
+  "result": "denied",
+  "reason": "Token verification failed: signature invalid",
+  "provider": "entra-oidc",
+  "scope": "bridge:edit"
+}
+```
+
+Token values are never logged. Use `redactSecrets` from `pforge-mcp/secrets.mjs` if any auth event data might contain token fragments.
+
+---
+
+## Constraints
+
+- **No required npm dependencies in this phase.** The first real provider (`Phase-ENTRA-SSO`) will introduce `@azure/identity` as an optional dep, following the pattern established by the Foundry provider.
+- **`@azure/identity` is already available as an optional dep** (added by Phase-FOUNDRY-PROVIDER). SSO providers that use Entra / Managed Identity may import it dynamically without a new `package.json` entry.
+- **The `claims` object on the identity shape is open for extension.** SSO providers may attach arbitrary claims without breaking the `AuthResult` contract.
+- **SSO providers should be stateless per request.** Caching JWKS keys or token introspection results is allowed (and encouraged for performance) but must be safe for concurrent calls.
+
+---
+
+## Future Providers (Planned)
+
+| Phase | Provider | Notes |
+|---|---|---|
+| Phase-ENTRA-SSO | Entra ID / Azure AD OIDC | JWT validation via `@azure/identity` (already optional dep) |
+| Phase-OKTA-SSO | Okta OIDC | Standard OIDC discovery doc |
+| Phase-GITHUB-OIDC | GitHub Actions OIDC | Validates `sub` claim for CI/CD automation |


### PR DESCRIPTION
Final slice of the Priority-C enterprise-readiness chain (drafted from docs/research/enterprise-fleet-readiness.md §14 Priority C).

## Phase 4 Slice 8 — Three docs + CHANGELOG

Slices 1-7 of Phase-AUTH-RBAC-SCAFFOLD already on master:
- 1-5: auth module + RBAC resolver + middleware + bridge refactor + server.mjs wiring
- 6: `auth-rbac.test.mjs` (37 tests covering RBAC resolver, bearer, SSO stub, dispatch, middleware)
- 7: full test suite verification (4503 passed, 2 pre-existing baseline failures noted)

This PR ships only Slice 8: documentation + CHANGELOG entry.

### Files
- `docs/security/auth-model.md` (179 lines) — pluggable auth model, bearer provider, identity shape, security boundaries
- `docs/security/sso-extension-point.md` (224 lines) — SSO provider interface, lifecycle, error handling, implementation guide
- `docs/security/rbac-config.md` (275 lines) — `.forge/rbac.json` schema, scope syntax, built-in catalogue, common patterns
- `CHANGELOG.md` `[Unreleased]` entry under `Phase-AUTH-RBAC-SCAFFOLD`

### Cost
- Slice 8 alone: \.01 / 129s
- Phase 4 total: \.07 / ~55 min
- **Priority-C chain total: \.32 declared, \.00 wall** (gh-copilot subscription path)

### Closes
Completes the Priority-C chain (4 phases, 34 slices) per `docs/research/enterprise-fleet-readiness.md` §14.